### PR TITLE
fix(fetch): make multipart boundary generation JS-safe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         run: dart analyze
 
       - name: Run tests
-        run: dart test
+        run: dart test -p vm -p node -p chrome
 
       - name: Run example
         run: dart run example/main.dart

--- a/lib/src/fetch/form_data.native.dart
+++ b/lib/src/fetch/form_data.native.dart
@@ -75,6 +75,9 @@ final class EncodedFormData {
 }
 
 class FormData with Iterable<MapEntry<String, Multipart>> {
+  static final _boundaryRandom = Random();
+  static var _boundaryCounter = 0;
+
   static Future<FormData> parse(Body body, {String? contentType}) async {
     final essence = _contentTypeEssence(contentType);
     return switch (essence) {
@@ -427,12 +430,14 @@ class FormData with Iterable<MapEntry<String, Multipart>> {
 
   static String _generateBoundary() {
     const alphabet = 'abcdefghijklmnopqrstuvwxyz0123456789';
-    final random = Random.secure();
-    final suffix = List<String>.generate(
-      24,
-      (_) => alphabet[random.nextInt(alphabet.length)],
-      growable: false,
-    ).join();
+    final suffix = StringBuffer()
+      ..write(DateTime.now().microsecondsSinceEpoch.toRadixString(36))
+      ..write((_boundaryCounter++).toRadixString(36));
+
+    for (var index = 0; index < 16; index++) {
+      suffix.write(alphabet[_boundaryRandom.nextInt(alphabet.length)]);
+    }
+
     return '----ht-$suffix';
   }
 

--- a/test/form_data_native_test.dart
+++ b/test/form_data_native_test.dart
@@ -159,6 +159,27 @@ void main() {
   });
 
   group('FormData.encodeMultipart (native)', () {
+    test('generates a default multipart boundary', () async {
+      final encoded = (FormData()..append('name', const Multipart.text('ht')))
+          .encodeMultipart();
+
+      expect(encoded.boundary, startsWith('----ht-'));
+      expect(encoded.boundary, matches(RegExp(r'^----ht-[a-z0-9]+$')));
+      expect(
+        encoded.contentType,
+        'multipart/form-data; boundary=${encoded.boundary}',
+      );
+
+      final bytes = await encoded.bytes();
+      expect(bytes.length, encoded.contentLength);
+
+      final parsed = await FormData.parse(
+        Body(encoded.stream),
+        contentType: encoded.contentType,
+      );
+      expect((parsed.get('name')! as TextMultipart).value, 'ht');
+    });
+
     test('returns encoded multipart metadata and payload', () async {
       final encoded =
           (FormData()


### PR DESCRIPTION
## Summary

- replace `Random.secure()` in multipart boundary generation with a platform-safe generator
- add coverage for default `FormData.encodeMultipart()` boundary generation
- run the full test suite on VM, Node, and Chrome in CI

## Root Cause

`Random.secure()` is unavailable in Dart's Node-backed test runtime, so callers that relied on the default multipart boundary path could fail unless they supplied their own boundary.

## Validation

- `dart format --output=none --set-exit-if-changed .`
- `dart analyze`
- `dart test -p vm -p node -p chrome`

Closes #14