### PR TITLE
docs: update README request examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ import 'package:ht/ht.dart';
 
 Future<void> main() async {
   final request = Request(
-    RequestInput.uri(Uri.parse('https://api.example.com/tasks')),
+    Uri.parse('https://api.example.com/tasks'),
     RequestInit(
       method: HttpMethod.post,
       headers: Headers({'content-type': 'application/json; charset=utf-8'}),
@@ -102,7 +102,7 @@ import 'package:ht/ht.dart';
 Future<void> main() async {
   final body = block.Block(<Object>['hello'], type: 'text/plain');
   final request = Request(
-    RequestInput.uri(Uri.parse('https://example.com')),
+    Uri.parse('https://example.com'),
     RequestInit(method: HttpMethod.post, body: body),
   );
 


### PR DESCRIPTION
## Summary

- Replace stale `RequestInput.uri(...)` README snippets with direct `Uri.parse(...)` inputs.
- Keep README request construction aligned with the current public `Request` API and `example/main.dart`.

## Root Cause

`RequestInput` is now an internal implementation detail, but README examples still referenced it as if it were public API.

Closes #16

## Validation

- `dart format --output=none --set-exit-if-changed .`
- `dart analyze`
- `dart test -p vm -p node -p chrome`
- `dart run example/main.dart`