### PR TITLE
fix: handle io header multi-values

### DIFF
--- a/lib/src/fetch/headers.io.dart
+++ b/lib/src/fetch/headers.io.dart
@@ -75,9 +75,11 @@ class Headers
   String? get(String name) {
     switch (_host) {
       case final HttpHeadersHost host:
-        return name.toLowerCase() == 'set-cookie'
-            ? null
-            : host.value.value(name);
+        final normalizedName = _normalizeName(name);
+        if (normalizedName == 'set-cookie') return null;
+
+        final values = host.value[normalizedName];
+        return values == null || values.isEmpty ? null : values.join(', ');
       case final NativeHeadersHost host:
         return host.value.get(name);
     }
@@ -107,7 +109,8 @@ class Headers
   bool has(String name) {
     switch (_host) {
       case final HttpHeadersHost host:
-        return host.value.value(name) != null;
+        final values = host.value[_normalizeName(name)];
+        return values != null && values.isNotEmpty;
       case final NativeHeadersHost host:
         return host.value.has(name);
     }
@@ -140,4 +143,6 @@ class Headers
         yield* host.value.values();
     }
   }
+
+  static String _normalizeName(String name) => name.trim().toLowerCase();
 }

--- a/test/headers_io_test.dart
+++ b/test/headers_io_test.dart
@@ -1,0 +1,41 @@
+@TestOn('vm')
+library;
+
+import 'dart:io';
+
+import 'package:ht/src/fetch/headers.io.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Headers (io)', () {
+    test('joins repeated values from dart:io HttpHeaders hosts', () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      final client = HttpClient();
+      addTearDown(() async {
+        client.close(force: true);
+        await server.close(force: true);
+      });
+
+      final serverRequestFuture = server.first;
+      final clientRequest = await client.get(
+        InternetAddress.loopbackIPv4.host,
+        server.port,
+        '/headers',
+      );
+      clientRequest.headers
+        ..add('x-multi', 'one')
+        ..add('x-multi', 'two');
+
+      final headers = Headers(clientRequest.headers);
+      expect(headers.has('x-multi'), isTrue);
+      expect(headers.get('x-multi'), 'one, two');
+      expect(headers.get('missing'), isNull);
+
+      final clientResponseFuture = clientRequest.close();
+      final serverRequest = await serverRequestFuture;
+      await serverRequest.response.close();
+      final clientResponse = await clientResponseFuture;
+      await clientResponse.drain<void>();
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Read repeated `dart:io HttpHeaders` values through the value list instead of `HttpHeaders.value()`.
- Join non-`set-cookie` repeated values with `, ` to match the native `Headers` behavior.
- Add VM regression coverage for real `HttpHeaders` hosts with repeated values.

## Root Cause

The IO adapter delegated `Headers.get()` and `Headers.has()` to `HttpHeaders.value()`. That Dart API throws when a header has more than one value, which diverged from ht's fetch-style `Headers` semantics.

Closes #17

## Validation

- `dart format --output=none --set-exit-if-changed lib/src/fetch/headers.io.dart test/headers_io_test.dart`
- `dart analyze`
- `dart test -p vm test/headers_io_test.dart test/headers_test.dart`
- `dart test -p vm -p node -p chrome`
- `dart run example/main.dart`
- `git diff --check`