### PR TITLE
fix: stabilize URLSearchParams sort

### DIFF
--- a/lib/src/fetch/url_search_params.native.dart
+++ b/lib/src/fetch/url_search_params.native.dart
@@ -96,7 +96,19 @@ class URLSearchParams with Iterable<MapEntry<String, String>> {
   }
 
   void sort() {
-    _entries.sort((a, b) => a.key.compareTo(b.key));
+    final indexedEntries =
+        [
+          for (var index = 0; index < _entries.length; index++)
+            (index: index, entry: _entries[index]),
+        ]..sort((a, b) {
+          final byName = a.entry.key.compareTo(b.entry.key);
+          if (byName != 0) return byName;
+          return a.index.compareTo(b.index);
+        });
+
+    _entries
+      ..clear()
+      ..addAll(indexedEntries.map((item) => item.entry));
   }
 
   Iterable<String> values() sync* {

--- a/test/url_search_params_js_test.dart
+++ b/test/url_search_params_js_test.dart
@@ -19,5 +19,10 @@ void main() {
       expect(wrapped.size, 3);
       expect(wrapped.toString(), 'a=1&a=2&b=3');
     });
+
+    test('sort keeps duplicate names in relative order', () {
+      final params = URLSearchParams('b=1&a=first&a=second&b=2')..sort();
+      expect(params.toString(), 'a=first&a=second&b=1&b=2');
+    });
   });
 }

--- a/test/url_search_params_test.dart
+++ b/test/url_search_params_test.dart
@@ -31,6 +31,11 @@ void main() {
       expect(params.toString(), 'a=2&z=1');
     });
 
+    test('sort keeps duplicate names in relative order', () {
+      final params = URLSearchParams('b=1&a=first&a=second&b=2')..sort();
+      expect(params.toString(), 'a=first&a=second&b=1&b=2');
+    });
+
     test('supports map and entry-list construction', () {
       final byMap = URLSearchParams({'a': '1', 'b': '2'});
       expect(byMap.toString(), 'a=1&b=2');


### PR DESCRIPTION
## Summary

- Make native `URLSearchParams.sort()` stable for duplicate parameter names by preserving original indexes as a tie-breaker.
- Add VM coverage for duplicate-name sorting.
- Add browser parity coverage for JS-backed `URLSearchParams.sort()`.

## Root Cause

The native implementation delegated directly to `List.sort`, which does not guarantee stable ordering. Fetch/Web `URLSearchParams.sort()` semantics require preserving the relative order of entries with the same name.

Closes #19

## Validation

- `dart format --output=none --set-exit-if-changed .`
- `dart analyze`
- `dart test -p vm test/url_search_params_test.dart`
- `dart test -p chrome test/url_search_params_js_test.dart`
- `dart test -p vm -p node -p chrome`
- `dart run example/main.dart`
- `git diff --check`