### PR TITLE
fix: clarify BodyInit file support contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,22 @@ Future<void> main() async {
 - Reading the same instance again throws `StateError`
 - Use `clone()` when multiple reads are required
 
+On IO, `dart:io` files are supported through `Blob` parts before becoming a
+body:
+
+```dart
+import 'dart:io' as io;
+
+import 'package:ht/ht.dart';
+
+Future<void> main() async {
+  final file = io.File('payload.txt');
+  final body = Body(Blob(<Object>[file], 'text/plain'));
+
+  print(await body.text());
+}
+```
+
 ## FormData Example
 
 ```dart

--- a/lib/src/fetch/body.dart
+++ b/lib/src/fetch/body.dart
@@ -23,8 +23,8 @@ import 'url_search_params.dart';
 /// - [FormData]
 /// - [URLSearchParams]
 ///
-/// Platform-specific extensions:
-/// - `dart:io File` on io
+/// On IO, `dart:io File` values are supported as [Blob] parts. Wrap files in a
+/// [Blob] before passing them as [BodyInit], for example `Body(Blob([file]))`.
 ///
 /// Native bodies normalize supported inputs into a detached [block.Block]
 /// when possible. Platform implementations may accept additional host-backed

--- a/test/blob_io_test.dart
+++ b/test/blob_io_test.dart
@@ -4,6 +4,7 @@ library;
 import 'dart:convert';
 import 'dart:io' as io;
 
+import 'package:ht/src/fetch/body.dart';
 import 'package:ht/src/fetch/blob.io.dart' as io_blob;
 import 'package:test/test.dart';
 
@@ -26,6 +27,25 @@ void main() {
       expect(blob.type, 'text/plain');
       expect(await blob.text(), 'hello world');
     });
+
+    test(
+      'works as a BodyInit value after wrapping dart:io File parts',
+      () async {
+        final tempDir = await io.Directory.systemTemp.createTemp('ht_blob_io_');
+        addTearDown(() async {
+          if (await tempDir.exists()) {
+            await tempDir.delete(recursive: true);
+          }
+        });
+
+        final file = io.File('${tempDir.path}/payload.txt');
+        await file.writeAsString('hello body');
+
+        final body = Body(io_blob.Blob([file], 'text/plain'));
+
+        expect(await body.text(), 'hello body');
+      },
+    );
 
     test('slice reads the requested file range', () async {
       final tempDir = await io.Directory.systemTemp.createTemp('ht_blob_io_');


### PR DESCRIPTION
## Summary

- Clarify that `BodyInit` does not accept direct `dart:io File` values.
- Document the supported IO file path through `Body(Blob([file]))`.
- Add VM coverage for using an IO-backed `Blob` as a body value.

Closes #18

## Validation

- `dart format --output=none --set-exit-if-changed .`
- `dart analyze`
- `dart test -p vm test/blob_io_test.dart`
- `dart test -p vm -p node -p chrome`
- `dart run example/main.dart`
- `git diff --check`