### PR TITLE
fix: enforce Fetch constructor invariants

### DIFF
--- a/lib/src/fetch/request.io.dart
+++ b/lib/src/fetch/request.io.dart
@@ -228,7 +228,8 @@ class Request implements native.Request {
 
   @override
   Request clone() {
-    final body = this.body;
+    final method = this.method;
+    final body = method.allowsRequestBody ? this.body : null;
     return Request(
       native.Request(
         url,
@@ -271,12 +272,15 @@ class Request implements native.Request {
     Request request,
     native.RequestInit? init,
   ) {
-    final body = init?.body == null ? request.body : null;
+    final method = init?.method ?? request.method;
+    final body = init?.body == null
+        ? _bodyFromWrappedRequest(request, method)
+        : null;
 
     return native.Request(
       request.url,
       native.RequestInit(
-        method: init?.method ?? request.method,
+        method: method,
         headers: init?.headers ?? io_headers.Headers(request.headers),
         body: init?.body ?? body?.clone(),
         referrer: init?.referrer ?? request.referrer,
@@ -290,5 +294,15 @@ class Request implements native.Request {
         duplex: init?.duplex ?? request.duplex,
       ),
     );
+  }
+
+  static Body? _bodyFromWrappedRequest(Request request, HttpMethod method) {
+    if (!method.allowsRequestBody &&
+        request._host is HttpRequestHost &&
+        !request.method.allowsRequestBody) {
+      return null;
+    }
+
+    return request.body;
   }
 }

--- a/lib/src/fetch/request.io.dart
+++ b/lib/src/fetch/request.io.dart
@@ -282,7 +282,7 @@ class Request implements native.Request {
       native.RequestInit(
         method: method,
         headers: init?.headers ?? io_headers.Headers(request.headers),
-        body: init?.body ?? body?.clone(),
+        body: init?.body ?? body,
         referrer: init?.referrer ?? request.referrer,
         referrerPolicy: init?.referrerPolicy ?? request.referrerPolicy,
         mode: init?.mode ?? request.mode,

--- a/lib/src/fetch/request.native.dart
+++ b/lib/src/fetch/request.native.dart
@@ -260,13 +260,13 @@ class Request {
     }
 
     final body = switch (input) {
-      _RequestRequestInput(:final value) => value.body?.clone(),
+      _RequestRequestInput(:final value) => value.body,
       _ => null,
     };
     if (body != null) {
       _validateRequestBodyMethod(method);
     }
-    return body;
+    return body?.clone();
   }
 
   static RequestCache _cacheFromInput(_RequestInput input, RequestCache? init) {

--- a/lib/src/fetch/request.native.dart
+++ b/lib/src/fetch/request.native.dart
@@ -133,8 +133,13 @@ class Request {
     : this._(_coerceInput(_requireInput(input)), init);
 
   Request._(_RequestInput input, [RequestInit? init])
-    : headers = _headersFromInput(input, init?.headers),
-      body = _bodyFromInput(input, init?.body),
+    : method = _methodFromInput(input, init?.method),
+      headers = _headersFromInput(input, init?.headers),
+      body = _bodyFromInput(
+        input,
+        init?.body,
+        _methodFromInput(input, init?.method),
+      ),
       cache = _cacheFromInput(input, init?.cache),
       credentials = _credentialsFromInput(input, init?.credentials),
       destination = _destinationFromInput(input),
@@ -142,7 +147,6 @@ class Request {
       integrity = _integrityFromInput(input, init?.integrity),
       isHistoryNavigation = _isHistoryNavigationFromInput(input),
       keepalive = _keepaliveFromInput(input, init?.keepalive),
-      method = _methodFromInput(input, init?.method),
       mode = _modeFromInput(input, init?.mode),
       redirect = _redirectFromInput(input, init?.redirect),
       referrer = _referrerFromInput(input, init?.referrer),
@@ -245,12 +249,24 @@ class Request {
     };
   }
 
-  static Body? _bodyFromInput(_RequestInput input, BodyInit? init) {
-    if (init != null) return Body(init);
-    return switch (input) {
+  static Body? _bodyFromInput(
+    _RequestInput input,
+    BodyInit? init,
+    HttpMethod method,
+  ) {
+    if (init != null) {
+      _validateRequestBodyMethod(method);
+      return Body(init);
+    }
+
+    final body = switch (input) {
       _RequestRequestInput(:final value) => value.body?.clone(),
       _ => null,
     };
+    if (body != null) {
+      _validateRequestBodyMethod(method);
+    }
+    return body;
   }
 
   static RequestCache _cacheFromInput(_RequestInput input, RequestCache? init) {
@@ -319,6 +335,18 @@ class Request {
       _RequestRequestInput(:final value) => value.method,
       _ => HttpMethod.get,
     };
+  }
+
+  static void _validateRequestBodyMethod(HttpMethod method) {
+    if (method.allowsRequestBody) {
+      return;
+    }
+
+    throw ArgumentError.value(
+      method,
+      'method',
+      '${method.value} requests cannot have a body.',
+    );
   }
 
   static RequestMode _modeFromInput(_RequestInput input, RequestMode? init) {

--- a/lib/src/fetch/response.io.dart
+++ b/lib/src/fetch/response.io.dart
@@ -192,7 +192,7 @@ class Response implements native.Response {
       final NativeResponseHost host => Response(host.value.clone()),
       final HttpClientResponseHost _ => Response(
         native.Response(
-          body?.clone(),
+          _bodyForNativeClone(),
           native.ResponseInit(
             status: status,
             statusText: statusText,
@@ -201,5 +201,21 @@ class Response implements native.Response {
         ),
       ),
     };
+  }
+
+  Body? _bodyForNativeClone() {
+    if (!_statusAllowsBody(status)) {
+      return null;
+    }
+
+    return body?.clone();
+  }
+
+  static bool _statusAllowsBody(int status) {
+    return !const <int>{
+      HttpStatus.noContent,
+      HttpStatus.resetContent,
+      HttpStatus.notModified,
+    }.contains(status);
   }
 }

--- a/lib/src/fetch/response.native.dart
+++ b/lib/src/fetch/response.native.dart
@@ -29,15 +29,19 @@ class ResponseInit {
 }
 
 class Response {
-  Response([BodyInit? body, ResponseInit? init])
-    : body = _bodyFromInit(body),
-      headers = _headersFromInit(init?.headers),
-      status = _validateStatus(init?.status ?? HttpStatus.ok),
-      statusText = init?.statusText ?? '',
-      ok = HttpStatus.isSuccess(init?.status ?? HttpStatus.ok),
-      redirected = false,
-      type = ResponseType.default_,
-      url = '';
+  factory Response([BodyInit? body, ResponseInit? init]) {
+    final status = _validateStatus(init?.status ?? HttpStatus.ok);
+    return Response._internal(
+      body: _bodyFromInit(body, status),
+      headers: _headersFromInit(init?.headers),
+      ok: HttpStatus.isSuccess(status),
+      redirected: false,
+      status: status,
+      statusText: init?.statusText ?? '',
+      type: ResponseType.default_,
+      url: '',
+    );
+  }
 
   Response._internal({
     required this.body,
@@ -172,9 +176,14 @@ class Response {
     );
   }
 
-  static Body? _bodyFromInit(BodyInit? init) {
+  static Body? _bodyFromInit(BodyInit? init, int status) {
     return switch (init) {
       null => null,
+      _ when _isNullBodyStatus(status) => throw ArgumentError.value(
+        init,
+        'body',
+        'Response status $status cannot have a body.',
+      ),
       _ => Body(init),
     };
   }
@@ -187,7 +196,17 @@ class Response {
   }
 
   static int _validateStatus(int status) {
-    HttpStatus.validate(status);
+    if (status < 200 || status > 599) {
+      throw RangeError.range(status, 200, 599, 'status');
+    }
     return status;
+  }
+
+  static bool _isNullBodyStatus(int status) {
+    return const <int>{
+      HttpStatus.noContent,
+      HttpStatus.resetContent,
+      HttpStatus.notModified,
+    }.contains(status);
   }
 }

--- a/test/request_io_test.dart
+++ b/test/request_io_test.dart
@@ -14,7 +14,7 @@ void main() {
       final request = io_request.Request(
         native.Request(
           'https://example.com',
-          native.RequestInit(body: 'payload'),
+          native.RequestInit(method: HttpMethod.post, body: 'payload'),
         ),
       );
 
@@ -120,6 +120,16 @@ void main() {
         expect(rebuilt.bodyUsed, isTrue);
       },
     );
+
+    test('rejects native construction bodies for bodyless methods', () {
+      expect(
+        () => io_request.Request(
+          'https://example.com',
+          native.RequestInit(method: HttpMethod.head, body: 'payload'),
+        ),
+        throwsArgumentError,
+      );
+    });
 
     test('wraps HttpRequest without copying headers or body eagerly', () async {
       final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);

--- a/test/request_io_test.dart
+++ b/test/request_io_test.dart
@@ -156,6 +156,9 @@ void main() {
           throwsArgumentError,
         );
 
+        expect(upstream.bodyUsed, isFalse);
+        expect(await upstream.text(), 'payload');
+
         httpRequest.response
           ..statusCode = HttpStatus.noContent
           ..close();

--- a/test/request_io_test.dart
+++ b/test/request_io_test.dart
@@ -90,6 +90,82 @@ void main() {
     });
 
     test(
+      'clones wrapped GET requests without forwarding empty host body',
+      () async {
+        final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+        addTearDown(server.close);
+        final port = server.port;
+
+        final requestFuture = server.first;
+
+        final client = HttpClient();
+        addTearDown(client.close);
+
+        final clientRequest = await client.get(
+          InternetAddress.loopbackIPv4.host,
+          port,
+          '/bodyless-clone',
+        );
+        final clientResponseFuture = clientRequest.close();
+
+        final httpRequest = await requestFuture;
+        final upstream = io_request.Request(httpRequest);
+        final clone = io_request.Request(upstream);
+
+        expect(clone.method, HttpMethod.get);
+        expect(clone.body, isNull);
+        expect(await clone.text(), '');
+
+        httpRequest.response
+          ..statusCode = HttpStatus.noContent
+          ..close();
+
+        final clientResponse = await clientResponseFuture;
+        await clientResponse.drain<void>();
+      },
+    );
+
+    test(
+      'rejects overriding wrapped bodyful requests to bodyless methods',
+      () async {
+        final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+        addTearDown(server.close);
+        final port = server.port;
+
+        final requestFuture = server.first;
+
+        final client = HttpClient();
+        addTearDown(client.close);
+
+        final clientRequest = await client.post(
+          InternetAddress.loopbackIPv4.host,
+          port,
+          '/bodyful-override',
+        );
+        clientRequest.write('payload');
+        final clientResponseFuture = clientRequest.close();
+
+        final httpRequest = await requestFuture;
+        final upstream = io_request.Request(httpRequest);
+
+        expect(
+          () => io_request.Request(
+            upstream,
+            native.RequestInit(method: HttpMethod.get),
+          ),
+          throwsArgumentError,
+        );
+
+        httpRequest.response
+          ..statusCode = HttpStatus.noContent
+          ..close();
+
+        final clientResponse = await clientResponseFuture;
+        await clientResponse.drain<void>();
+      },
+    );
+
+    test(
       'rebuilds consumed wrapped requests when init provides a replacement body',
       () async {
         final upstream = io_request.Request(

--- a/test/request_js_test.dart
+++ b/test/request_js_test.dart
@@ -123,6 +123,16 @@ void main() {
       },
     );
 
+    test('rejects native construction bodies for bodyless methods', () {
+      expect(
+        () => Request(
+          'https://example.com',
+          native.RequestInit(method: HttpMethod.head, body: 'payload'),
+        ),
+        throwsArgumentError,
+      );
+    });
+
     test('clone tees a wrapped web.Request body', () async {
       final upstream = web.Request(
         'https://example.com/clone'.toJS,

--- a/test/request_native_test.dart
+++ b/test/request_native_test.dart
@@ -251,5 +251,29 @@ void main() {
         throwsArgumentError,
       );
     });
+
+    test(
+      'rejects bodyless overrides before cloning inherited streams',
+      () async {
+        final upstream = Request(
+          'https://example.com',
+          RequestInit(
+            method: HttpMethod.post,
+            body: Stream<List<int>>.fromIterable(<List<int>>[
+              utf8.encode('pay'),
+              utf8.encode('load'),
+            ]),
+          ),
+        );
+
+        expect(
+          () => Request(upstream, RequestInit(method: HttpMethod.get)),
+          throwsArgumentError,
+        );
+
+        expect(upstream.bodyUsed, isFalse);
+        expect(await upstream.text(), 'payload');
+      },
+    );
   });
 }

--- a/test/request_native_test.dart
+++ b/test/request_native_test.dart
@@ -88,19 +88,19 @@ void main() {
 
       final bytesRequest = Request(
         'https://example.com/bytes',
-        RequestInit(body: utf8.encode('hello')),
+        RequestInit(method: HttpMethod.post, body: utf8.encode('hello')),
       );
       expect(utf8.decode(await bytesRequest.bytes()), 'hello');
 
       final arrayBufferRequest = Request(
         'https://example.com/array-buffer',
-        RequestInit(body: utf8.encode('hello')),
+        RequestInit(method: HttpMethod.post, body: utf8.encode('hello')),
       );
       expect(utf8.decode(await arrayBufferRequest.arrayBuffer()), 'hello');
 
       final parsedRequest = Request(
         'https://example.com/parsed',
-        RequestInit(body: '{"ok":true}'),
+        RequestInit(method: HttpMethod.post, body: '{"ok":true}'),
       );
       expect(await parsedRequest.json<Map<String, Object?>>(), {'ok': true});
 
@@ -114,6 +114,7 @@ void main() {
       final request = Request(
         'https://example.com/blob',
         RequestInit(
+          method: HttpMethod.post,
           headers: Headers({'content-type': 'application/custom'}),
           body: 'hello',
         ),
@@ -218,11 +219,37 @@ void main() {
     test('clone fails after body has been consumed', () async {
       final request = Request(
         'https://example.com/clone',
-        RequestInit(body: 'used'),
+        RequestInit(method: HttpMethod.post, body: 'used'),
       );
 
       expect(await request.text(), 'used');
       expect(() => request.clone(), throwsStateError);
+    });
+
+    test('rejects bodies for methods that cannot carry bodies', () {
+      expect(
+        () => Request('https://example.com', RequestInit(body: 'payload')),
+        throwsArgumentError,
+      );
+      expect(
+        () => Request(
+          'https://example.com',
+          RequestInit(method: HttpMethod.head, body: 'payload'),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('rejects inherited bodies when overriding to bodyless methods', () {
+      final upstream = Request(
+        'https://example.com',
+        RequestInit(method: HttpMethod.post, body: 'payload'),
+      );
+
+      expect(
+        () => Request(upstream, RequestInit(method: HttpMethod.get)),
+        throwsArgumentError,
+      );
     });
   });
 }

--- a/test/response_io_test.dart
+++ b/test/response_io_test.dart
@@ -20,6 +20,20 @@ void main() {
       expect(clone.ok, isFalse);
     });
 
+    test('enforces native constructor invariants', () {
+      expect(
+        () => Response(null, const native.ResponseInit(status: 199)),
+        throwsRangeError,
+      );
+      expect(
+        () => Response(
+          'payload',
+          const native.ResponseInit(status: io.HttpStatus.noContent),
+        ),
+        throwsArgumentError,
+      );
+    });
+
     test(
       'wraps HttpClientResponse without copying headers or body eagerly',
       () async {

--- a/test/response_io_test.dart
+++ b/test/response_io_test.dart
@@ -108,6 +108,36 @@ void main() {
       expect(await response.text(), 'ok');
     });
 
+    test('clones null-body HttpClientResponse statuses without body', () async {
+      final server = await io.HttpServer.bind(
+        io.InternetAddress.loopbackIPv4,
+        0,
+      );
+
+      addTearDown(server.close);
+
+      server.listen((request) {
+        request.response
+          ..statusCode = io.HttpStatus.noContent
+          ..close();
+      });
+
+      final client = io.HttpClient();
+      addTearDown(client.close);
+
+      final httpRequest = await client.getUrl(
+        Uri.parse('http://${server.address.host}:${server.port}/empty'),
+      );
+      final httpResponse = await httpRequest.close();
+
+      final response = Response(httpResponse);
+      final clone = response.clone();
+
+      expect(clone.status, io.HttpStatus.noContent);
+      expect(clone.body, isNull);
+      expect(await clone.text(), '');
+    });
+
     test('clone tees HttpClientResponse body streams', () async {
       final server = await io.HttpServer.bind(
         io.InternetAddress.loopbackIPv4,

--- a/test/response_js_test.dart
+++ b/test/response_js_test.dart
@@ -87,6 +87,17 @@ void main() {
       expect(await json.text(), '{"ok":true}');
     });
 
+    test('enforces native constructor invariants', () {
+      expect(
+        () => Response(null, const native.ResponseInit(status: 199)),
+        throwsRangeError,
+      );
+      expect(
+        () => Response('payload', const native.ResponseInit(status: 204)),
+        throwsArgumentError,
+      );
+    });
+
     test('reads formData directly from web host', () async {
       final formResponse = Response(
         web.Response(

--- a/test/response_native_test.dart
+++ b/test/response_native_test.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:ht/src/core/http_status.dart';
 import 'package:ht/src/fetch/blob.dart';
 import 'package:ht/src/fetch/form_data.native.dart';
 import 'package:ht/src/fetch/headers.dart';
@@ -61,6 +62,53 @@ void main() {
       expect(response.ok, isTrue);
       expect(response.headers.get('x-id'), '1');
       expect(await response.text(), 'payload');
+    });
+
+    test('rejects constructor statuses outside the Fetch range', () {
+      expect(
+        () => Response(null, const ResponseInit(status: 199)),
+        throwsRangeError,
+      );
+      expect(
+        () => Response(null, const ResponseInit(status: 600)),
+        throwsRangeError,
+      );
+      expect(
+        () => Response(null, const ResponseInit(status: 200)),
+        returnsNormally,
+      );
+      expect(
+        () => Response(null, const ResponseInit(status: 599)),
+        returnsNormally,
+      );
+    });
+
+    test('rejects bodies for null-body statuses', () {
+      expect(
+        () => Response(null, const ResponseInit(status: HttpStatus.noContent)),
+        returnsNormally,
+      );
+      expect(
+        () => Response(
+          'payload',
+          const ResponseInit(status: HttpStatus.noContent),
+        ),
+        throwsArgumentError,
+      );
+      expect(
+        () => Response(
+          'payload',
+          const ResponseInit(status: HttpStatus.resetContent),
+        ),
+        throwsArgumentError,
+      );
+      expect(
+        () => Response(
+          'payload',
+          const ResponseInit(status: HttpStatus.notModified),
+        ),
+        throwsArgumentError,
+      );
     });
 
     test('json factory encodes payload and sets content-type', () async {


### PR DESCRIPTION
## Summary

- Enforce request body invariants by rejecting `RequestInit.body` or inherited bodies when the effective method disallows request bodies.
- Restrict `Response()` constructor statuses to the Fetch-compatible `200..599` range while preserving internal `Response.error()` status `0`.
- Reject response bodies for null-body statuses `204`, `205`, and `304`.
- Update native, IO, and JS wrapper tests to cover the stricter constructor behavior.

## Decision

This chooses strict Fetch/Web constructor semantics for ht instead of documenting a looser HTTP type-layer contract. The codebase already models method body support through `HttpMethod.allowsRequestBody`, so the constructors now enforce that modeled boundary.

Closes #20

## Validation

- `dart format --output=none --set-exit-if-changed .`
- `dart analyze`
- `dart test -p vm test/request_native_test.dart test/response_native_test.dart test/request_io_test.dart test/response_io_test.dart`
- `dart test -p chrome test/request_js_test.dart test/response_js_test.dart`
- `dart test -p vm -p node -p chrome`
- `dart run example/main.dart`
- `git diff --check`