### PR TITLE
feat: harden multipart form-data parsing

### DIFF
--- a/lib/src/fetch/form_data.native.dart
+++ b/lib/src/fetch/form_data.native.dart
@@ -692,6 +692,11 @@ final class _MultipartStreamParser {
   final _buffer = <int>[];
   final _formData = FormData();
 
+  int get _boundaryTailRetain =>
+      _prefixedBoundaryMarker.length +
+      FormData._dashDash.length +
+      FormData._crlf.length;
+
   var _state = _MultipartParseState.firstBoundary;
   Map<String, String>? _partHeaders;
   _ContentDisposition? _partDisposition;
@@ -936,18 +941,16 @@ final class _MultipartStreamParser {
   }
 
   void _flushSafeContentPrefix() {
-    final retain = _prefixedBoundaryMarker.length + FormData._dashDash.length;
-    if (_buffer.length <= retain) return;
+    if (_buffer.length <= _boundaryTailRetain) return;
 
-    final end = _buffer.length - retain;
+    final end = _buffer.length - _boundaryTailRetain;
     _addContentChunk(0, end);
     _consume(end);
   }
 
   void _discardSafePreamblePrefix() {
-    final retain = _prefixedBoundaryMarker.length + FormData._dashDash.length;
-    if (_buffer.length <= retain) return;
-    _consume(_buffer.length - retain);
+    if (_buffer.length <= _boundaryTailRetain) return;
+    _consume(_buffer.length - _boundaryTailRetain);
   }
 
   void _addContentChunk(int start, int end) {

--- a/lib/src/fetch/form_data.native.dart
+++ b/lib/src/fetch/form_data.native.dart
@@ -2,6 +2,8 @@ import 'dart:convert';
 import 'dart:math';
 import 'dart:typed_data';
 
+import 'package:http_parser/http_parser.dart' as http_parser;
+
 import 'blob.dart';
 import 'body.dart';
 import 'file.dart';
@@ -75,14 +77,16 @@ final class EncodedFormData {
 }
 
 class FormData with Iterable<MapEntry<String, Multipart>> {
+  static const _crlf = <int>[0x0d, 0x0a];
+  static const _dashDash = <int>[0x2d, 0x2d];
   static final _boundaryRandom = Random();
   static var _boundaryCounter = 0;
 
   static Future<FormData> parse(Body body, {String? contentType}) async {
-    final essence = _contentTypeEssence(contentType);
-    return switch (essence) {
+    final mediaType = _parseContentType(contentType);
+    return switch (mediaType?.mimeType ?? '') {
       'application/x-www-form-urlencoded' => _parseUrlEncoded(body),
-      'multipart/form-data' => _parseMultipart(body, contentType: contentType),
+      'multipart/form-data' => _parseMultipart(body, mediaType: mediaType!),
       '' => throw UnsupportedError('Unsupported form content type: (missing)'),
       _ => throw UnsupportedError(
         'Unsupported form content type: ${contentType ?? '(missing)'}',
@@ -174,9 +178,9 @@ class FormData with Iterable<MapEntry<String, Multipart>> {
 
   static Future<FormData> _parseMultipart(
     Body body, {
-    required String? contentType,
+    required http_parser.MediaType mediaType,
   }) async {
-    final boundary = _boundaryFromContentType(contentType);
+    final boundary = _boundaryFromContentType(mediaType);
     if (boundary == null || boundary.isEmpty) {
       throw const FormatException(
         'Missing multipart boundary in content-type.',
@@ -185,36 +189,45 @@ class FormData with Iterable<MapEntry<String, Multipart>> {
 
     final bytes = await body.bytes();
     final boundaryMarker = utf8.encode('--$boundary');
-    final boundaryPrefix = utf8.encode('\r\n--$boundary');
+    final prefixedBoundaryMarker = <int>[..._crlf, ...boundaryMarker];
     final headerSeparator = utf8.encode('\r\n\r\n');
     final formData = FormData();
 
-    var offset = _indexOf(bytes, boundaryMarker);
-    if (offset == -1) {
+    final firstBoundary = _findFirstBoundary(
+      bytes,
+      boundaryMarker,
+      prefixedBoundaryMarker,
+    );
+    if (firstBoundary == null) {
       throw const FormatException('Multipart body does not contain boundary.');
     }
 
-    while (offset != -1) {
-      offset += boundaryMarker.length;
-
-      if (_matches(bytes, offset, utf8.encode('--'))) {
+    var boundaryMatch = firstBoundary;
+    while (true) {
+      if (boundaryMatch.closing) {
         break;
       }
 
-      if (!_matches(bytes, offset, utf8.encode('\r\n'))) {
-        throw const FormatException('Invalid multipart boundary separator.');
-      }
-      offset += 2;
+      final offset = boundaryMatch.afterMarker + _crlf.length;
 
       final headerEnd = _indexOf(bytes, headerSeparator, offset);
       if (headerEnd == -1) {
         throw const FormatException('Invalid multipart part headers.');
       }
 
-      final headers = _parsePartHeaders(bytes.sublist(offset, headerEnd));
+      final headers = _parsePartHeaders(
+        Uint8List.sublistView(bytes, offset, headerEnd),
+      );
       final contentStart = headerEnd + headerSeparator.length;
-      final nextBoundary = _indexOf(bytes, boundaryPrefix, contentStart);
-      if (nextBoundary == -1) {
+      // Only a line that is followed by CRLF or "--" is a real delimiter.
+      // Boundary-like bytes inside file payloads must remain part of the body.
+      final nextBoundary = _findNextBoundary(
+        bytes,
+        boundaryMarker,
+        prefixedBoundaryMarker,
+        contentStart,
+      );
+      if (nextBoundary == null) {
         throw const FormatException(
           'Multipart part is missing a closing boundary.',
         );
@@ -223,60 +236,48 @@ class FormData with Iterable<MapEntry<String, Multipart>> {
       final contentBytes = Uint8List.sublistView(
         bytes,
         contentStart,
-        nextBoundary,
+        nextBoundary.lineStart,
       );
+      final disposition = _contentDispositionFromPartHeaders(headers);
       formData.append(
-        _fieldNameFromPartHeaders(headers),
-        _partBodyFromHeaders(headers, contentBytes),
+        disposition.name,
+        _partBodyFromHeaders(headers, disposition, contentBytes),
       );
-
-      offset = nextBoundary + 2;
+      boundaryMatch = nextBoundary;
     }
 
     return formData;
   }
 
-  static String _contentTypeEssence(String? contentType) {
-    if (contentType == null) return '';
-
-    final separator = contentType.indexOf(';');
-    final essence = separator == -1
-        ? contentType
-        : contentType.substring(0, separator);
-    return essence.trim().toLowerCase();
+  static http_parser.MediaType? _parseContentType(String? contentType) {
+    if (contentType == null) return null;
+    _parseParameterizedHeaderValue(contentType, 'content-type');
+    return http_parser.MediaType.parse(contentType);
   }
 
-  static String? _boundaryFromContentType(String? contentType) {
-    if (contentType == null) return null;
-
-    final segments = contentType.split(';');
-    for (final rawSegment in segments.skip(1)) {
-      final segment = rawSegment.trim();
-      if (!segment.toLowerCase().startsWith('boundary=')) {
-        continue;
-      }
-
-      final value = segment.substring('boundary='.length).trim();
-      if (value.length >= 2 && value.startsWith('"') && value.endsWith('"')) {
-        return value.substring(1, value.length - 1);
-      }
-      return value;
-    }
-
-    return null;
+  static String? _boundaryFromContentType(http_parser.MediaType mediaType) {
+    return mediaType.parameters['boundary'];
   }
 
   static Map<String, String> _parsePartHeaders(Uint8List bytes) {
-    final text = latin1.decode(bytes);
+    final text = _decodeHeaderBytes(bytes);
     final headers = <String, String>{};
+    if (text.isEmpty) return headers;
 
     for (final line in text.split('\r\n')) {
       final separator = line.indexOf(':');
       if (separator <= 0) {
-        continue;
+        throw FormatException('Invalid multipart part header: $line');
       }
 
       final name = line.substring(0, separator).trim().toLowerCase();
+      if (!_isHttpToken(name)) {
+        throw FormatException('Invalid multipart part header name: $name');
+      }
+      if (headers.containsKey(name)) {
+        throw FormatException('Duplicate multipart part header: $name');
+      }
+
       final value = line.substring(separator + 1).trim();
       headers[name] = value;
     }
@@ -284,28 +285,8 @@ class FormData with Iterable<MapEntry<String, Multipart>> {
     return headers;
   }
 
-  static String _fieldNameFromPartHeaders(Map<String, String> headers) {
-    final disposition = headers['content-disposition'];
-    if (disposition == null) {
-      throw const FormatException(
-        'Multipart part is missing content-disposition.',
-      );
-    }
-
-    final parameters = _parseHeaderParameters(disposition);
-    final name = parameters['name'];
-    if (name == null || name.isEmpty) {
-      throw const FormatException(
-        'Multipart part is missing content-disposition name.',
-      );
-    }
-
-    return name;
-  }
-
-  static Multipart _partBodyFromHeaders(
+  static _ContentDisposition _contentDispositionFromPartHeaders(
     Map<String, String> headers,
-    Uint8List bytes,
   ) {
     final disposition = headers['content-disposition'];
     if (disposition == null) {
@@ -314,41 +295,118 @@ class FormData with Iterable<MapEntry<String, Multipart>> {
       );
     }
 
-    final parameters = _parseHeaderParameters(disposition);
-    final filename = parameters['filename'];
+    final parsed = _parseParameterizedHeaderValue(
+      disposition,
+      'content-disposition',
+    );
+    if (parsed.value.toLowerCase() != 'form-data') {
+      throw const FormatException(
+        'Multipart part content-disposition must be form-data.',
+      );
+    }
+
+    final parameters = parsed.parameters;
+    final name = parameters['name'];
+    if (name == null || name.isEmpty) {
+      throw const FormatException(
+        'Multipart part is missing content-disposition name.',
+      );
+    }
+
+    return _ContentDisposition(name, _filenameFromDisposition(parameters));
+  }
+
+  static Multipart _partBodyFromHeaders(
+    Map<String, String> headers,
+    _ContentDisposition disposition,
+    Uint8List bytes,
+  ) {
+    final contentType = _partContentType(headers);
+    final filename = disposition.filename;
     if (filename != null) {
       return Multipart.blob(
-        Blob(<BlobPart>[bytes], headers['content-type'] ?? ''),
+        Blob(<BlobPart>[bytes], contentType?.raw ?? ''),
         filename,
       );
     }
 
-    return Multipart.text(utf8.decode(bytes));
+    return Multipart.text(_decodeTextPart(bytes, contentType?.mediaType));
   }
 
-  static Map<String, String> _parseHeaderParameters(String value) {
+  static _PartContentType? _partContentType(Map<String, String> headers) {
+    final raw = headers['content-type'];
+    if (raw == null || raw.isEmpty) return null;
+
+    _parseParameterizedHeaderValue(raw, 'part content-type');
+    return _PartContentType(raw, http_parser.MediaType.parse(raw));
+  }
+
+  static String? _filenameFromDisposition(Map<String, String> parameters) {
+    final filenameStar = parameters['filename*'];
+    if (filenameStar != null) {
+      // RFC 7578 tells senders not to use filename*, but deployed clients do.
+      // Accept it for interop and prefer it over the plain fallback filename.
+      return _decodeExtendedParameterValue(filenameStar, 'filename*');
+    }
+
+    return parameters['filename'];
+  }
+
+  static String _decodeTextPart(
+    Uint8List bytes,
+    http_parser.MediaType? mediaType,
+  ) {
+    final charset = mediaType?.parameters['charset'];
+    return _encodingForCharset(charset).decode(bytes);
+  }
+
+  static Encoding _encodingForCharset(String? charset) {
+    if (charset == null || charset.isEmpty) return utf8;
+
+    final normalized = charset.toLowerCase();
+    return switch (normalized) {
+      'utf-8' || 'utf8' => utf8,
+      'iso-8859-1' || 'latin1' || 'latin-1' => latin1,
+      'us-ascii' || 'ascii' => ascii,
+      _ =>
+        Encoding.getByName(normalized) ??
+            (throw FormatException('Unsupported multipart charset: $charset')),
+    };
+  }
+
+  static _ParsedHeaderValue _parseParameterizedHeaderValue(
+    String value,
+    String context,
+  ) {
+    final segments = _splitHeaderParameters(value, context);
+    final primaryValue = segments.first.trim();
+    if (primaryValue.isEmpty) {
+      throw FormatException('Invalid $context header value.');
+    }
+
     final parameters = <String, String>{};
-    for (final segment in _splitHeaderParameters(value).skip(1)) {
+    for (final segment in segments.skip(1)) {
       final separator = segment.indexOf('=');
       if (separator == -1) {
-        continue;
+        throw FormatException('Invalid $context parameter: $segment');
       }
 
       final name = segment.substring(0, separator).trim().toLowerCase();
-      var parameterValue = segment.substring(separator + 1).trim();
-      if (parameterValue.length >= 2 &&
-          parameterValue.startsWith('"') &&
-          parameterValue.endsWith('"')) {
-        parameterValue = parameterValue.substring(1, parameterValue.length - 1);
+      if (!_isHttpToken(name)) {
+        throw FormatException('Invalid $context parameter name: $name');
+      }
+      if (parameters.containsKey(name)) {
+        throw FormatException('Duplicate $context parameter: $name');
       }
 
-      parameters[name] = _unescapeHeaderValue(parameterValue);
+      final parameterValue = segment.substring(separator + 1).trim();
+      parameters[name] = _parseHeaderParameterValue(parameterValue, context);
     }
 
-    return parameters;
+    return _ParsedHeaderValue(primaryValue, parameters);
   }
 
-  static List<String> _splitHeaderParameters(String value) {
+  static List<String> _splitHeaderParameters(String value, String context) {
     final segments = <String>[];
     final buffer = StringBuffer();
     var quoted = false;
@@ -363,7 +421,7 @@ class FormData with Iterable<MapEntry<String, Multipart>> {
         continue;
       }
 
-      if (char == r'\') {
+      if (quoted && char == r'\') {
         buffer.write(char);
         escaped = true;
         continue;
@@ -385,11 +443,227 @@ class FormData with Iterable<MapEntry<String, Multipart>> {
     }
 
     segments.add(buffer.toString());
+    if (quoted || escaped) {
+      throw FormatException('Invalid quoted $context parameter.');
+    }
     return segments;
   }
 
-  static String _unescapeHeaderValue(String value) {
-    return value.replaceAll(r'\\', '\\').replaceAll(r'\"', '"');
+  static String _parseHeaderParameterValue(String value, String context) {
+    if (value.isEmpty) {
+      throw FormatException('Invalid empty $context parameter value.');
+    }
+
+    if (value.startsWith('"')) {
+      return _parseQuotedHeaderValue(value, context);
+    }
+
+    if (!_isHttpToken(value)) {
+      throw FormatException('Invalid $context parameter value: $value');
+    }
+    return value;
+  }
+
+  static String _parseQuotedHeaderValue(String value, String context) {
+    if (value.length < 2 || !value.endsWith('"')) {
+      throw FormatException('Invalid quoted $context parameter.');
+    }
+
+    final buffer = StringBuffer();
+    for (var index = 1; index < value.length - 1; index++) {
+      final code = value.codeUnitAt(index);
+      if (code == 0x5c) {
+        index++;
+        if (index >= value.length - 1) {
+          throw FormatException('Invalid quoted $context parameter.');
+        }
+        final escaped = value.codeUnitAt(index);
+        if (escaped == 0x22 || escaped == 0x5c) {
+          buffer.writeCharCode(escaped);
+        } else {
+          buffer
+            ..writeCharCode(code)
+            ..writeCharCode(escaped);
+        }
+        continue;
+      }
+
+      if (code == 0x22 || code < 0x20 || code == 0x7f) {
+        throw FormatException('Invalid quoted $context parameter.');
+      }
+      buffer.writeCharCode(code);
+    }
+
+    return buffer.toString();
+  }
+
+  static String _decodeExtendedParameterValue(String value, String context) {
+    final firstQuote = value.indexOf("'");
+    final secondQuote = firstQuote == -1
+        ? -1
+        : value.indexOf("'", firstQuote + 1);
+    if (firstQuote <= 0 || secondQuote == -1) {
+      throw FormatException('Invalid extended $context parameter.');
+    }
+
+    final charset = value.substring(0, firstQuote);
+    final encodedValue = value.substring(secondQuote + 1);
+    final bytes = <int>[];
+
+    for (var index = 0; index < encodedValue.length; index++) {
+      final code = encodedValue.codeUnitAt(index);
+      if (code == 0x25) {
+        if (index + 2 >= encodedValue.length) {
+          throw FormatException('Invalid percent-encoded $context parameter.');
+        }
+
+        final byte = _hexByte(
+          encodedValue.codeUnitAt(index + 1),
+          encodedValue.codeUnitAt(index + 2),
+        );
+        if (byte == null) {
+          throw FormatException('Invalid percent-encoded $context parameter.');
+        }
+
+        bytes.add(byte);
+        index += 2;
+        continue;
+      }
+
+      if (code > 0x7f) {
+        throw FormatException('Invalid extended $context parameter.');
+      }
+      bytes.add(code);
+    }
+
+    return _encodingForCharset(charset).decode(bytes);
+  }
+
+  static int? _hexByte(int high, int low) {
+    final highValue = _hexValue(high);
+    final lowValue = _hexValue(low);
+    if (highValue == null || lowValue == null) return null;
+    return highValue * 16 + lowValue;
+  }
+
+  static int? _hexValue(int code) {
+    if (code >= 0x30 && code <= 0x39) return code - 0x30;
+    if (code >= 0x41 && code <= 0x46) return code - 0x41 + 10;
+    if (code >= 0x61 && code <= 0x66) return code - 0x61 + 10;
+    return null;
+  }
+
+  static String _decodeHeaderBytes(Uint8List bytes) {
+    try {
+      return utf8.decode(bytes, allowMalformed: false);
+    } on FormatException {
+      return latin1.decode(bytes);
+    }
+  }
+
+  static bool _isHttpToken(String value) {
+    if (value.isEmpty) return false;
+    for (var index = 0; index < value.length; index++) {
+      if (!_isHttpTokenCodeUnit(value.codeUnitAt(index))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  static bool _isHttpTokenCodeUnit(int code) {
+    if (code <= 0x20 || code >= 0x7f) return false;
+    return switch (code) {
+      0x28 || // (
+      0x29 || // )
+      0x3c || // <
+      0x3e || // >
+      0x40 || // @
+      0x2c || // ,
+      0x3b || // ;
+      0x3a || // :
+      0x22 || // "
+      0x5c || // \
+      0x2f || // /
+      0x5b || // [
+      0x5d || // ]
+      0x3f || // ?
+      0x3d || // =
+      0x7b || // {
+      0x7d => // }
+      false,
+      _ => true,
+    };
+  }
+
+  static _BoundaryMatch? _findFirstBoundary(
+    Uint8List bytes,
+    List<int> boundaryMarker,
+    List<int> prefixedBoundaryMarker,
+  ) {
+    if (_matches(bytes, 0, boundaryMarker)) {
+      final first = _boundaryMatchAt(bytes, 0, 0, boundaryMarker);
+      if (first != null) return first;
+      throw const FormatException('Invalid multipart boundary separator.');
+    }
+
+    return _findNextBoundary(bytes, boundaryMarker, prefixedBoundaryMarker, 0);
+  }
+
+  static _BoundaryMatch? _findNextBoundary(
+    Uint8List bytes,
+    List<int> boundaryMarker,
+    List<int> prefixedBoundaryMarker,
+    int start,
+  ) {
+    var offset = start;
+
+    while (offset != -1) {
+      final lineStart = _indexOf(bytes, prefixedBoundaryMarker, offset);
+      if (lineStart == -1) return null;
+
+      final match = _boundaryMatchAt(
+        bytes,
+        lineStart,
+        lineStart + _crlf.length,
+        boundaryMarker,
+      );
+      if (match != null) return match;
+
+      offset = lineStart + 1;
+    }
+
+    return null;
+  }
+
+  static _BoundaryMatch? _boundaryMatchAt(
+    Uint8List bytes,
+    int lineStart,
+    int markerStart,
+    List<int> boundaryMarker,
+  ) {
+    if (!_matches(bytes, markerStart, boundaryMarker)) {
+      return null;
+    }
+
+    final afterMarker = markerStart + boundaryMarker.length;
+    if (_matches(bytes, afterMarker, _dashDash)) {
+      return _BoundaryMatch(
+        lineStart: lineStart,
+        afterMarker: afterMarker + _dashDash.length,
+        closing: true,
+      );
+    }
+
+    if (_matches(bytes, afterMarker, _crlf)) {
+      return _BoundaryMatch(
+        lineStart: lineStart,
+        afterMarker: afterMarker,
+        closing: false,
+      );
+    }
+
+    return null;
   }
 
   static int _indexOf(List<int> haystack, List<int> needle, [int start = 0]) {
@@ -516,4 +790,37 @@ class FormData with Iterable<MapEntry<String, Multipart>> {
 
   static Uint8List _utf8(String value) =>
       Uint8List.fromList(utf8.encode(value));
+}
+
+final class _BoundaryMatch {
+  const _BoundaryMatch({
+    required this.lineStart,
+    required this.afterMarker,
+    required this.closing,
+  });
+
+  final int lineStart;
+  final int afterMarker;
+  final bool closing;
+}
+
+final class _ContentDisposition {
+  const _ContentDisposition(this.name, this.filename);
+
+  final String name;
+  final String? filename;
+}
+
+final class _ParsedHeaderValue {
+  const _ParsedHeaderValue(this.value, this.parameters);
+
+  final String value;
+  final Map<String, String> parameters;
+}
+
+final class _PartContentType {
+  const _PartContentType(this.raw, this.mediaType);
+
+  final String raw;
+  final http_parser.MediaType mediaType;
 }

--- a/lib/src/fetch/form_data.native.dart
+++ b/lib/src/fetch/form_data.native.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:math';
 import 'dart:typed_data';
 
+import 'package:block/block.dart' as block;
 import 'package:http_parser/http_parser.dart' as http_parser;
 
 import 'blob.dart';
@@ -187,66 +188,7 @@ class FormData with Iterable<MapEntry<String, Multipart>> {
       );
     }
 
-    final bytes = await body.bytes();
-    final boundaryMarker = utf8.encode('--$boundary');
-    final prefixedBoundaryMarker = <int>[..._crlf, ...boundaryMarker];
-    final headerSeparator = utf8.encode('\r\n\r\n');
-    final formData = FormData();
-
-    final firstBoundary = _findFirstBoundary(
-      bytes,
-      boundaryMarker,
-      prefixedBoundaryMarker,
-    );
-    if (firstBoundary == null) {
-      throw const FormatException('Multipart body does not contain boundary.');
-    }
-
-    var boundaryMatch = firstBoundary;
-    while (true) {
-      if (boundaryMatch.closing) {
-        break;
-      }
-
-      final offset = boundaryMatch.afterMarker + _crlf.length;
-
-      final headerEnd = _indexOf(bytes, headerSeparator, offset);
-      if (headerEnd == -1) {
-        throw const FormatException('Invalid multipart part headers.');
-      }
-
-      final headers = _parsePartHeaders(
-        Uint8List.sublistView(bytes, offset, headerEnd),
-      );
-      final contentStart = headerEnd + headerSeparator.length;
-      // Only a line that is followed by CRLF or "--" is a real delimiter.
-      // Boundary-like bytes inside file payloads must remain part of the body.
-      final nextBoundary = _findNextBoundary(
-        bytes,
-        boundaryMarker,
-        prefixedBoundaryMarker,
-        contentStart,
-      );
-      if (nextBoundary == null) {
-        throw const FormatException(
-          'Multipart part is missing a closing boundary.',
-        );
-      }
-
-      final contentBytes = Uint8List.sublistView(
-        bytes,
-        contentStart,
-        nextBoundary.lineStart,
-      );
-      final disposition = _contentDispositionFromPartHeaders(headers);
-      formData.append(
-        disposition.name,
-        _partBodyFromHeaders(headers, disposition, contentBytes),
-      );
-      boundaryMatch = nextBoundary;
-    }
-
-    return formData;
+    return _MultipartStreamParser(body, boundary).parse();
   }
 
   static http_parser.MediaType? _parseContentType(String? contentType) {
@@ -319,18 +261,26 @@ class FormData with Iterable<MapEntry<String, Multipart>> {
   static Multipart _partBodyFromHeaders(
     Map<String, String> headers,
     _ContentDisposition disposition,
-    Uint8List bytes,
+    List<Uint8List> chunks,
   ) {
     final contentType = _partContentType(headers);
     final filename = disposition.filename;
     if (filename != null) {
+      final type = contentType?.raw ?? '';
       return Multipart.blob(
-        Blob(<BlobPart>[bytes], contentType?.raw ?? ''),
+        Blob(<BlobPart>[block.Block(chunks, type: type)], type),
         filename,
       );
     }
 
-    return Multipart.text(_decodeTextPart(bytes, contentType?.mediaType));
+    final builder = BytesBuilder(copy: false);
+    for (final chunk in chunks) {
+      builder.add(chunk);
+    }
+
+    return Multipart.text(
+      _decodeTextPart(builder.takeBytes(), contentType?.mediaType),
+    );
   }
 
   static _PartContentType? _partContentType(Map<String, String> headers) {
@@ -596,76 +546,6 @@ class FormData with Iterable<MapEntry<String, Multipart>> {
     };
   }
 
-  static _BoundaryMatch? _findFirstBoundary(
-    Uint8List bytes,
-    List<int> boundaryMarker,
-    List<int> prefixedBoundaryMarker,
-  ) {
-    if (_matches(bytes, 0, boundaryMarker)) {
-      final first = _boundaryMatchAt(bytes, 0, 0, boundaryMarker);
-      if (first != null) return first;
-      throw const FormatException('Invalid multipart boundary separator.');
-    }
-
-    return _findNextBoundary(bytes, boundaryMarker, prefixedBoundaryMarker, 0);
-  }
-
-  static _BoundaryMatch? _findNextBoundary(
-    Uint8List bytes,
-    List<int> boundaryMarker,
-    List<int> prefixedBoundaryMarker,
-    int start,
-  ) {
-    var offset = start;
-
-    while (offset != -1) {
-      final lineStart = _indexOf(bytes, prefixedBoundaryMarker, offset);
-      if (lineStart == -1) return null;
-
-      final match = _boundaryMatchAt(
-        bytes,
-        lineStart,
-        lineStart + _crlf.length,
-        boundaryMarker,
-      );
-      if (match != null) return match;
-
-      offset = lineStart + 1;
-    }
-
-    return null;
-  }
-
-  static _BoundaryMatch? _boundaryMatchAt(
-    Uint8List bytes,
-    int lineStart,
-    int markerStart,
-    List<int> boundaryMarker,
-  ) {
-    if (!_matches(bytes, markerStart, boundaryMarker)) {
-      return null;
-    }
-
-    final afterMarker = markerStart + boundaryMarker.length;
-    if (_matches(bytes, afterMarker, _dashDash)) {
-      return _BoundaryMatch(
-        lineStart: lineStart,
-        afterMarker: afterMarker + _dashDash.length,
-        closing: true,
-      );
-    }
-
-    if (_matches(bytes, afterMarker, _crlf)) {
-      return _BoundaryMatch(
-        lineStart: lineStart,
-        afterMarker: afterMarker,
-        closing: false,
-      );
-    }
-
-    return null;
-  }
-
   static int _indexOf(List<int> haystack, List<int> needle, [int start = 0]) {
     if (needle.isEmpty) {
       return start <= haystack.length ? start : -1;
@@ -790,6 +670,270 @@ class FormData with Iterable<MapEntry<String, Multipart>> {
 
   static Uint8List _utf8(String value) =>
       Uint8List.fromList(utf8.encode(value));
+}
+
+enum _MultipartParseState { firstBoundary, headers, content, closed }
+
+final class _MultipartStreamParser {
+  _MultipartStreamParser(this._body, String boundary)
+    : _boundaryMarker = utf8.encode('--$boundary'),
+      _prefixedBoundaryMarker = <int>[
+        ...FormData._crlf,
+        ...utf8.encode('--$boundary'),
+      ],
+      _headerSeparator = utf8.encode('\r\n\r\n');
+
+  final Body _body;
+  final List<int> _boundaryMarker;
+  final List<int> _prefixedBoundaryMarker;
+  final List<int> _headerSeparator;
+  final _buffer = <int>[];
+  final _formData = FormData();
+
+  var _state = _MultipartParseState.firstBoundary;
+  Map<String, String>? _partHeaders;
+  _ContentDisposition? _partDisposition;
+  List<Uint8List>? _partChunks;
+
+  Future<FormData> parse() async {
+    await for (final chunk in _body) {
+      if (_state == _MultipartParseState.closed) {
+        continue;
+      }
+
+      _append(chunk);
+      _drain();
+    }
+
+    _finish();
+    return _formData;
+  }
+
+  void _append(Uint8List chunk) {
+    if (chunk.isEmpty) return;
+    _buffer.addAll(chunk);
+  }
+
+  void _drain() {
+    var advanced = true;
+    while (advanced && _state != _MultipartParseState.closed) {
+      advanced = _advance();
+    }
+
+    if (_state == _MultipartParseState.closed) {
+      _buffer.clear();
+    }
+  }
+
+  bool _advance() {
+    return switch (_state) {
+      _MultipartParseState.firstBoundary => _advanceFirstBoundary(),
+      _MultipartParseState.headers => _advanceHeaders(),
+      _MultipartParseState.content => _advanceContent(),
+      _MultipartParseState.closed => false,
+    };
+  }
+
+  bool _advanceFirstBoundary() {
+    final match = _findFirstBoundary();
+    if (match == null) return false;
+
+    _consumeBoundary(match);
+    return true;
+  }
+
+  bool _advanceHeaders() {
+    final headerEnd = FormData._indexOf(_buffer, _headerSeparator);
+    if (headerEnd == -1) return false;
+
+    final headers = FormData._parsePartHeaders(
+      Uint8List.fromList(_buffer.sublist(0, headerEnd)),
+    );
+
+    _partHeaders = headers;
+    _partDisposition = FormData._contentDispositionFromPartHeaders(headers);
+    _partChunks = <Uint8List>[];
+    _consume(headerEnd + _headerSeparator.length);
+    _state = _MultipartParseState.content;
+    return true;
+  }
+
+  bool _advanceContent() {
+    // Only a line that is followed by CRLF or "--" is a real delimiter.
+    // Boundary-like bytes inside file payloads must remain part of the body.
+    final match = _findNextBoundary();
+    if (match == null) {
+      _flushSafeContentPrefix();
+      return false;
+    }
+
+    _addContentChunk(0, match.lineStart);
+    final headers = _partHeaders!;
+    final disposition = _partDisposition!;
+    _formData.append(
+      disposition.name,
+      FormData._partBodyFromHeaders(headers, disposition, _partChunks!),
+    );
+
+    _partHeaders = null;
+    _partDisposition = null;
+    _partChunks = null;
+    _consumeBoundary(match);
+    return true;
+  }
+
+  void _finish() {
+    _drain();
+    switch (_state) {
+      case _MultipartParseState.closed:
+        return;
+      case _MultipartParseState.firstBoundary:
+        throw const FormatException(
+          'Multipart body does not contain boundary.',
+        );
+      case _MultipartParseState.headers:
+        throw const FormatException('Invalid multipart part headers.');
+      case _MultipartParseState.content:
+        throw const FormatException(
+          'Multipart part is missing a closing boundary.',
+        );
+    }
+  }
+
+  _BoundaryMatch? _findFirstBoundary() {
+    if (_buffer.isEmpty) return null;
+
+    if (_couldMatchAt(0, _boundaryMarker)) {
+      final probe = _probeBoundaryAt(0, 0);
+      if (probe.needMore) return null;
+      if (probe.match case final match?) return match;
+      throw const FormatException('Invalid multipart boundary separator.');
+    }
+
+    final match = _findNextBoundary();
+    if (match != null) return match;
+    _discardSafePreamblePrefix();
+    return null;
+  }
+
+  _BoundaryMatch? _findNextBoundary() {
+    var offset = 0;
+
+    while (offset != -1) {
+      final lineStart = FormData._indexOf(
+        _buffer,
+        _prefixedBoundaryMarker,
+        offset,
+      );
+      if (lineStart == -1) return null;
+
+      final probe = _probeBoundaryAt(
+        lineStart,
+        lineStart + FormData._crlf.length,
+      );
+      if (probe.needMore) return null;
+      if (probe.match case final match?) return match;
+
+      offset = lineStart + 1;
+    }
+
+    return null;
+  }
+
+  _BoundaryProbe _probeBoundaryAt(int lineStart, int markerStart) {
+    final markerAvailable = _buffer.length - markerStart;
+    if (markerAvailable < _boundaryMarker.length) {
+      return const _BoundaryProbe.needMore();
+    }
+
+    if (!FormData._matches(_buffer, markerStart, _boundaryMarker)) {
+      return const _BoundaryProbe.invalid();
+    }
+
+    final afterMarker = markerStart + _boundaryMarker.length;
+    if (_buffer.length - afterMarker < 2) {
+      return const _BoundaryProbe.needMore();
+    }
+
+    if (FormData._matches(_buffer, afterMarker, FormData._dashDash)) {
+      return _BoundaryProbe.match(
+        _BoundaryMatch(
+          lineStart: lineStart,
+          afterMarker: afterMarker + FormData._dashDash.length,
+          closing: true,
+        ),
+      );
+    }
+
+    if (FormData._matches(_buffer, afterMarker, FormData._crlf)) {
+      return _BoundaryProbe.match(
+        _BoundaryMatch(
+          lineStart: lineStart,
+          afterMarker: afterMarker,
+          closing: false,
+        ),
+      );
+    }
+
+    return const _BoundaryProbe.invalid();
+  }
+
+  bool _couldMatchAt(int start, List<int> needle) {
+    final available = _buffer.length - start;
+    if (available <= 0) return false;
+
+    final length = available < needle.length ? available : needle.length;
+    for (var index = 0; index < length; index++) {
+      if (_buffer[start + index] != needle[index]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  void _consumeBoundary(_BoundaryMatch match) {
+    final count = match.closing
+        ? match.afterMarker
+        : match.afterMarker + FormData._crlf.length;
+    _consume(count);
+    _state = match.closing
+        ? _MultipartParseState.closed
+        : _MultipartParseState.headers;
+  }
+
+  void _flushSafeContentPrefix() {
+    final retain = _prefixedBoundaryMarker.length + FormData._dashDash.length;
+    if (_buffer.length <= retain) return;
+
+    final end = _buffer.length - retain;
+    _addContentChunk(0, end);
+    _consume(end);
+  }
+
+  void _discardSafePreamblePrefix() {
+    final retain = _prefixedBoundaryMarker.length + FormData._dashDash.length;
+    if (_buffer.length <= retain) return;
+    _consume(_buffer.length - retain);
+  }
+
+  void _addContentChunk(int start, int end) {
+    if (end <= start) return;
+    _partChunks!.add(Uint8List.fromList(_buffer.sublist(start, end)));
+  }
+
+  void _consume(int count) {
+    if (count <= 0) return;
+    _buffer.removeRange(0, count);
+  }
+}
+
+final class _BoundaryProbe {
+  const _BoundaryProbe.match(this.match) : needMore = false;
+  const _BoundaryProbe.needMore() : match = null, needMore = true;
+  const _BoundaryProbe.invalid() : match = null, needMore = false;
+
+  final _BoundaryMatch? match;
+  final bool needMore;
 }
 
 final class _BoundaryMatch {

--- a/lib/src/fetch/form_data.native.dart
+++ b/lib/src/fetch/form_data.native.dart
@@ -674,6 +674,8 @@ class FormData with Iterable<MapEntry<String, Multipart>> {
 
 enum _MultipartParseState { firstBoundary, headers, content, closed }
 
+enum _BoundaryLineEnd { valid, needMore, invalid }
+
 final class _MultipartStreamParser {
   _MultipartStreamParser(this._body, String boundary)
     : _boundaryMarker = utf8.encode('--$boundary'),
@@ -694,6 +696,7 @@ final class _MultipartStreamParser {
   Map<String, String>? _partHeaders;
   _ContentDisposition? _partDisposition;
   List<Uint8List>? _partChunks;
+  var _streamDone = false;
 
   Future<FormData> parse() async {
     await for (final chunk in _body) {
@@ -705,6 +708,7 @@ final class _MultipartStreamParser {
       _drain();
     }
 
+    _streamDone = true;
     _finish();
     return _formData;
   }
@@ -856,10 +860,20 @@ final class _MultipartStreamParser {
     }
 
     if (FormData._matches(_buffer, afterMarker, FormData._dashDash)) {
+      final closingEnd = afterMarker + FormData._dashDash.length;
+      switch (_probeBoundaryLineEnd(closingEnd)) {
+        case _BoundaryLineEnd.needMore:
+          return const _BoundaryProbe.needMore();
+        case _BoundaryLineEnd.invalid:
+          return const _BoundaryProbe.invalid();
+        case _BoundaryLineEnd.valid:
+          break;
+      }
+
       return _BoundaryProbe.match(
         _BoundaryMatch(
           lineStart: lineStart,
-          afterMarker: afterMarker + FormData._dashDash.length,
+          afterMarker: closingEnd,
           closing: true,
         ),
       );
@@ -876,6 +890,26 @@ final class _MultipartStreamParser {
     }
 
     return const _BoundaryProbe.invalid();
+  }
+
+  _BoundaryLineEnd _probeBoundaryLineEnd(int offset) {
+    final available = _buffer.length - offset;
+    if (available == 0) {
+      return _streamDone ? _BoundaryLineEnd.valid : _BoundaryLineEnd.needMore;
+    }
+
+    if (available == 1) {
+      if (_buffer[offset] == FormData._crlf.first && !_streamDone) {
+        return _BoundaryLineEnd.needMore;
+      }
+      return _BoundaryLineEnd.invalid;
+    }
+
+    if (FormData._matches(_buffer, offset, FormData._crlf)) {
+      return _BoundaryLineEnd.valid;
+    }
+
+    return _BoundaryLineEnd.invalid;
   }
 
   bool _couldMatchAt(int start, List<int> needle) {

--- a/test/form_data_native_test.dart
+++ b/test/form_data_native_test.dart
@@ -280,6 +280,23 @@ void main() {
       expect(await file.text(), 'payload');
     });
 
+    test('parses closing boundaries split after trailing CR', () async {
+      const boundary = 'split-closing-boundary';
+      final formData = await FormData.parse(
+        _bodyChunks([
+          '--$boundary\r\n'
+              'Content-Disposition: form-data; name="file"; filename="a.txt"\r\n'
+              'Content-Type: text/plain\r\n'
+              '\r\npayload\r\n--$boundary--\r',
+          '\n',
+        ]),
+        contentType: 'multipart/form-data; boundary=$boundary',
+      );
+
+      final file = formData.get('file')! as BlobMultipart;
+      expect(await file.text(), 'payload');
+    });
+
     test('parses RFC 5987 filename star parameters', () async {
       const boundary = 'filename-star-boundary';
       final formData = await FormData.parse(

--- a/test/form_data_native_test.dart
+++ b/test/form_data_native_test.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:ht/src/fetch/body.dart';
@@ -83,6 +84,206 @@ void main() {
       expect(blob.filename, 'a.txt');
       expect(blob.type, 'text/plain;charset=utf-8');
       expect(await blob.text(), 'binary');
+    });
+
+    test('parses quoted multipart boundary values', () async {
+      const boundary = 'quoted-boundary';
+      final formData = await FormData.parse(
+        _bodyBytes([
+          '--$boundary\r\n'
+              'Content-Disposition: form-data; name="field"\r\n'
+              '\r\n'
+              'value\r\n'
+              '--$boundary--\r\n',
+        ]),
+        contentType: 'multipart/form-data; boundary="$boundary"',
+      );
+
+      expect((formData.get('field')! as TextMultipart).value, 'value');
+    });
+
+    test('rejects duplicate content-type boundary parameters', () async {
+      const boundary = 'duplicate-boundary';
+
+      await expectLater(
+        FormData.parse(
+          _bodyBytes(['--$boundary--\r\n']),
+          contentType:
+              'multipart/form-data; boundary=$boundary; boundary=other',
+        ),
+        throwsFormatException,
+      );
+    });
+
+    test('rejects malformed multipart boundary separators', () async {
+      const boundary = 'malformed-boundary';
+
+      await expectLater(
+        FormData.parse(
+          _bodyBytes([
+            '--$boundary\n'
+                'Content-Disposition: form-data; name="field"\r\n'
+                '\r\n'
+                'value\r\n'
+                '--$boundary--\r\n',
+          ]),
+          contentType: 'multipart/form-data; boundary=$boundary',
+        ),
+        throwsFormatException,
+      );
+    });
+
+    test('rejects multipart parts without content-disposition', () async {
+      const boundary = 'missing-disposition-boundary';
+
+      await expectLater(
+        FormData.parse(
+          _bodyBytes([
+            '--$boundary\r\n'
+                'Content-Type: text/plain\r\n'
+                '\r\n'
+                'value\r\n'
+                '--$boundary--\r\n',
+          ]),
+          contentType: 'multipart/form-data; boundary=$boundary',
+        ),
+        throwsFormatException,
+      );
+    });
+
+    test('rejects duplicate multipart part headers', () async {
+      const boundary = 'duplicate-header-boundary';
+
+      await expectLater(
+        FormData.parse(
+          _bodyBytes([
+            '--$boundary\r\n'
+                'Content-Disposition: form-data; name="a"\r\n'
+                'Content-Disposition: form-data; name="b"\r\n'
+                '\r\n'
+                'value\r\n'
+                '--$boundary--\r\n',
+          ]),
+          contentType: 'multipart/form-data; boundary=$boundary',
+        ),
+        throwsFormatException,
+      );
+    });
+
+    test('rejects duplicate content-disposition parameters', () async {
+      const boundary = 'duplicate-parameter-boundary';
+
+      await expectLater(
+        FormData.parse(
+          _bodyBytes([
+            '--$boundary\r\n'
+                'Content-Disposition: form-data; name="a"; name="b"\r\n'
+                '\r\n'
+                'value\r\n'
+                '--$boundary--\r\n',
+          ]),
+          contentType: 'multipart/form-data; boundary=$boundary',
+        ),
+        throwsFormatException,
+      );
+    });
+
+    test('decodes text parts with explicit charset parameters', () async {
+      const boundary = 'charset-boundary';
+      final formData = await FormData.parse(
+        _bodyBytes([
+          '--$boundary\r\n'
+              'Content-Disposition: form-data; name="title"\r\n'
+              'Content-Type: text/plain; charset=iso-8859-1\r\n'
+              '\r\n',
+          [0x63, 0x61, 0x66, 0xe9],
+          '\r\n--$boundary--\r\n',
+        ]),
+        contentType: 'multipart/form-data; boundary=$boundary',
+      );
+
+      expect((formData.get('title')! as TextMultipart).value, 'caf\u00e9');
+    });
+
+    test('keeps boundary-like bytes inside binary payloads', () async {
+      const boundary = 'binary-boundary';
+      final formData = await FormData.parse(
+        _bodyBytes([
+          '--$boundary\r\n'
+              'Content-Disposition: form-data; name="file"; filename="a.bin"\r\n'
+              'Content-Type: application/octet-stream\r\n'
+              '\r\n'
+              'before\r\n'
+              '--$boundary-not-a-delimiter\r\n'
+              'after\r\n'
+              '--$boundary--\r\n',
+        ]),
+        contentType: 'multipart/form-data; boundary=$boundary',
+      );
+
+      final file = formData.get('file')! as BlobMultipart;
+      expect(
+        await file.text(),
+        'before\r\n--$boundary-not-a-delimiter\r\nafter',
+      );
+    });
+
+    test('parses RFC 5987 filename star parameters', () async {
+      const boundary = 'filename-star-boundary';
+      final formData = await FormData.parse(
+        _bodyBytes([
+          '--$boundary\r\n'
+              "Content-Disposition: form-data; name=\"file\"; filename*=UTF-8''caf%C3%A9.txt\r\n"
+              'Content-Type: text/plain\r\n'
+              '\r\n'
+              'payload\r\n'
+              '--$boundary--\r\n',
+        ]),
+        contentType: 'multipart/form-data; boundary=$boundary',
+      );
+
+      final file = formData.get('file')! as BlobMultipart;
+      expect(file.filename, 'caf\u00e9.txt');
+      expect(await file.text(), 'payload');
+    });
+
+    test('prefers filename star over filename fallback', () async {
+      const boundary = 'filename-priority-boundary';
+      final formData = await FormData.parse(
+        _bodyBytes([
+          '--$boundary\r\n'
+              'Content-Disposition: form-data; name="file"; '
+              'filename="fallback.txt"; filename*=UTF-8\'\'%E2%82%ACrates.txt\r\n'
+              'Content-Type: text/plain\r\n'
+              '\r\n'
+              'payload\r\n'
+              '--$boundary--\r\n',
+        ]),
+        contentType: 'multipart/form-data; boundary=$boundary',
+      );
+
+      expect(
+        (formData.get('file')! as BlobMultipart).filename,
+        '\u20acrates.txt',
+      );
+    });
+
+    test('rejects multipart parts without form-data disposition', () async {
+      const boundary = 'invalid-disposition-boundary';
+
+      await expectLater(
+        FormData.parse(
+          _bodyBytes([
+            '--$boundary\r\n'
+                'Content-Disposition: attachment; name="file"; filename="a.txt"\r\n'
+                '\r\n'
+                'payload\r\n'
+                '--$boundary--\r\n',
+          ]),
+          contentType: 'multipart/form-data; boundary=$boundary',
+        ),
+        throwsFormatException,
+      );
     });
 
     test('parses quoted multipart parameters containing semicolons', () async {
@@ -228,4 +429,19 @@ void main() {
       expect(entries, [('a', 'x'), ('b', '2')]);
     });
   });
+}
+
+Body _bodyBytes(List<Object> parts) {
+  final builder = BytesBuilder(copy: false);
+  for (final part in parts) {
+    switch (part) {
+      case final String value:
+        builder.add(ascii.encode(value));
+      case final List<int> value:
+        builder.add(value);
+      default:
+        throw ArgumentError.value(part, 'parts', 'Unsupported test body part.');
+    }
+  }
+  return Body(builder.takeBytes());
 }

--- a/test/form_data_native_test.dart
+++ b/test/form_data_native_test.dart
@@ -228,6 +228,29 @@ void main() {
       );
     });
 
+    test('keeps closing-boundary-like bytes inside binary payloads', () async {
+      const boundary = 'closing-like-boundary';
+      final formData = await FormData.parse(
+        _bodyBytes([
+          '--$boundary\r\n'
+              'Content-Disposition: form-data; name="file"; filename="a.bin"\r\n'
+              'Content-Type: application/octet-stream\r\n'
+              '\r\n'
+              'before\r\n'
+              '--$boundary--not-a-delimiter\r\n'
+              'after\r\n'
+              '--$boundary--\r\n',
+        ]),
+        contentType: 'multipart/form-data; boundary=$boundary',
+      );
+
+      final file = formData.get('file')! as BlobMultipart;
+      expect(
+        await file.text(),
+        'before\r\n--$boundary--not-a-delimiter\r\nafter',
+      );
+    });
+
     test('parses multipart bodies across stream chunk boundaries', () async {
       const boundary = 'stream-boundary';
       final formData = await FormData.parse(

--- a/test/form_data_native_test.dart
+++ b/test/form_data_native_test.dart
@@ -228,6 +228,35 @@ void main() {
       );
     });
 
+    test('parses multipart bodies across stream chunk boundaries', () async {
+      const boundary = 'stream-boundary';
+      final formData = await FormData.parse(
+        _bodyChunks([
+          '--str',
+          'eam-boundary\r',
+          '\nContent-Dis',
+          'position: form-data; name="field"\r\n\r\nhe',
+          'llo\r',
+          '\n--stream-bou',
+          'ndary\r\nContent-Disposition: form-data; '
+              'name="file"; filename="a.txt"\r\n'
+              'Content-Type: text/plain\r\n'
+              '\r\npay',
+          'load\r\n--stream-bound',
+          'ary--',
+          '\r\n',
+        ]),
+        contentType: 'multipart/form-data; boundary=$boundary',
+      );
+
+      expect((formData.get('field')! as TextMultipart).value, 'hello');
+
+      final file = formData.get('file')! as BlobMultipart;
+      expect(file.filename, 'a.txt');
+      expect(file.type, 'text/plain');
+      expect(await file.text(), 'payload');
+    });
+
     test('parses RFC 5987 filename star parameters', () async {
       const boundary = 'filename-star-boundary';
       final formData = await FormData.parse(
@@ -444,4 +473,8 @@ Body _bodyBytes(List<Object> parts) {
     }
   }
   return Body(builder.takeBytes());
+}
+
+Body _bodyChunks(List<String> chunks) {
+  return Body(Stream<List<int>>.fromIterable(chunks.map(ascii.encode)));
 }


### PR DESCRIPTION
## Summary
- Upgrade the native `multipart/form-data` parser to stream input chunks while validating media types, part headers, disposition parameters, and strict boundary delimiters.
- Add charset-aware text field decoding, RFC 5987 `filename*` compatibility, and protection for boundary-like bytes inside binary payloads.
- Keep parsed file parts on the existing `Blob`/`Block` lazy path instead of flattening them into one byte buffer.
- Expand parser interop/error coverage for quoted boundaries, malformed separators, duplicate headers/parameters, filename precedence, invalid dispositions, and chunk-split boundaries.

## Scope
- Keeps the public API unchanged.
- Streams multipart input parsing; text fields still decode to `String` per `TextMultipart`, while file fields remain `BlobMultipart` backed by a chunk-composed `Blob`.
- Focuses on HTTP `multipart/form-data`; this is not a general MIME mail parser.
- Accepts `filename*` for deployed-client interop and prefers it over the fallback `filename` when present.

Closes #21

## Validation
- `dart format --output=none --set-exit-if-changed .`
- `dart analyze`
- `dart test -p vm -p node -p chrome`
- `dart run example/main.dart`
- `git diff --check`