### PR TITLE
fix(fetch): copy IO Headers constructor input

### DIFF
--- a/lib/src/fetch/headers.io.dart
+++ b/lib/src/fetch/headers.io.dart
@@ -21,13 +21,13 @@ class Headers
   const Headers._(this._host);
 
   factory Headers([native.HeadersInit? init]) {
-    final host = switch (init) {
-      final Headers headers => headers._host,
+    return Headers._(switch (init) {
+      final Headers headers => NativeHeadersHost(
+        native.Headers(headers.entries()),
+      ),
       final HttpHeaders headers => HttpHeadersHost(headers),
       _ => NativeHeadersHost(native.Headers(init)),
-    };
-
-    return Headers._(host);
+    });
   }
 
   final HeadersHost _host;

--- a/test/headers_io_test.dart
+++ b/test/headers_io_test.dart
@@ -8,6 +8,14 @@ import 'package:test/test.dart';
 
 void main() {
   group('Headers (io)', () {
+    test('constructor from Headers creates independent copy', () {
+      final original = Headers({'x-test': '1'});
+      final copy = Headers(original)..set('x-test', '2');
+
+      expect(original.get('x-test'), '1');
+      expect(copy.get('x-test'), '2');
+    });
+
     test('joins repeated values from dart:io HttpHeaders hosts', () async {
       final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
       final client = HttpClient();


### PR DESCRIPTION
## Summary

- Copy entries when constructing IO `Headers` from an existing `Headers` object.
- Add a VM regression test proving the copied headers can be mutated independently.

## Root Cause

The IO adapter reused the existing `Headers` host for `Headers(existingHeaders)`, so both objects shared the same mutable backing store. Fetch `Headers` constructor semantics create a new headers object filled from the input instead.

## Impact

Mutating a `Headers` copy on `dart:io` no longer mutates the original headers object. `dart:io` `HttpHeaders` inputs still wrap the original host as before.

## Validation

- `dart analyze`
- `dart test test/headers_io_test.dart`
- `dart test`

Closes #34


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized header factory constructor implementation by eliminating intermediate variable references and streamlining conditional logic with no changes to functionality.

* **Tests**
  * Added test coverage verifying header instance independence: confirms that creating a header from an existing instance produces an independent copy whose mutations do not affect the original.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->