### PR TITLE
fix(fetch): align Headers iteration semantics

### DIFF
--- a/lib/src/fetch/headers.io.dart
+++ b/lib/src/fetch/headers.io.dart
@@ -59,13 +59,7 @@ class Headers
   Iterable<MapEntry<String, String>> entries() sync* {
     switch (_host) {
       case final HttpHeadersHost host:
-        final entries = <MapEntry<String, String>>[];
-        host.value.forEach((name, values) {
-          for (final value in values) {
-            entries.add(MapEntry(name, value));
-          }
-        });
-        yield* entries;
+        yield* native.Headers(_httpHeaderEntries(host.value)).entries();
       case final NativeHeadersHost host:
         yield* host.value.entries();
     }
@@ -119,12 +113,8 @@ class Headers
   @override
   Iterable<String> keys() sync* {
     switch (_host) {
-      case final HttpHeadersHost host:
-        final keys = <String>[];
-        host.value.forEach((name, values) {
-          keys.add(name);
-        });
-        yield* keys;
+      case HttpHeadersHost():
+        yield* entries().map((entry) => entry.key);
       case final NativeHeadersHost host:
         yield* host.value.keys();
     }
@@ -133,15 +123,23 @@ class Headers
   @override
   Iterable<String> values() sync* {
     switch (_host) {
-      case final HttpHeadersHost host:
-        final values = <String>[];
-        host.value.forEach((name, entries) {
-          values.addAll(entries);
-        });
-        yield* values;
+      case HttpHeadersHost():
+        yield* entries().map((entry) => entry.value);
       case final NativeHeadersHost host:
         yield* host.value.values();
     }
+  }
+
+  static Iterable<MapEntry<String, String>> _httpHeaderEntries(
+    HttpHeaders headers,
+  ) {
+    final entries = <MapEntry<String, String>>[];
+    headers.forEach((name, values) {
+      for (final value in values) {
+        entries.add(MapEntry(name, value));
+      }
+    });
+    return entries;
   }
 
   static String _normalizeName(String name) => name.trim().toLowerCase();

--- a/lib/src/fetch/headers.native.dart
+++ b/lib/src/fetch/headers.native.dart
@@ -68,7 +68,7 @@ class Headers with Iterable<MapEntry<String, String>> {
   final List<MapEntry<String, String>> _host;
 
   @override
-  Iterator<MapEntry<String, String>> get iterator => _host.iterator;
+  Iterator<MapEntry<String, String>> get iterator => entries().iterator;
 
   void append(String name, String value) {
     _host.add(
@@ -84,7 +84,21 @@ class Headers with Iterable<MapEntry<String, String>> {
     _host.removeWhere((entry) => entry.key == normalizedName);
   }
 
-  Iterable<MapEntry<String, String>> entries() => _host;
+  Iterable<MapEntry<String, String>> entries() sync* {
+    final names = _host.map((entry) => entry.key).toSet().toList()..sort();
+    for (final name in names) {
+      final values = _host
+          .where((entry) => entry.key == name)
+          .map((entry) => entry.value);
+      if (name == 'set-cookie') {
+        for (final value in values) {
+          yield MapEntry(name, value);
+        }
+      } else {
+        yield MapEntry(name, values.join(', '));
+      }
+    }
+  }
 
   String? get(String name) {
     final normalizedName = _normalizeAndValidateName(name);
@@ -116,14 +130,9 @@ class Headers with Iterable<MapEntry<String, String>> {
     return _host.any((entry) => entry.key == normalizedName);
   }
 
-  Iterable<String> keys() {
-    final seen = <String>{};
-    return _host.map((entry) => entry.key).where(seen.add);
-  }
+  Iterable<String> keys() => entries().map((entry) => entry.key);
 
-  Iterable<String> values() {
-    return _host.map((entry) => entry.value);
-  }
+  Iterable<String> values() => entries().map((entry) => entry.value);
 
   static String _normalizeAndValidateName(String name) {
     final normalized = name.trim().toLowerCase();

--- a/test/headers_io_test.dart
+++ b/test/headers_io_test.dart
@@ -16,7 +16,7 @@ void main() {
       expect(copy.get('x-test'), '2');
     });
 
-    test('joins repeated values from dart:io HttpHeaders hosts', () async {
+    test('combines iteration from dart:io HttpHeaders hosts', () async {
       final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
       final client = HttpClient();
       addTearDown(() async {
@@ -31,13 +31,41 @@ void main() {
         '/headers',
       );
       clientRequest.headers
+        ..add('x-b', 'b1')
+        ..add('X-A', 'a1')
+        ..add('x-a', 'a2')
         ..add('x-multi', 'one')
-        ..add('x-multi', 'two');
+        ..add('x-multi', 'two')
+        ..add(HttpHeaders.setCookieHeader, 's1=1')
+        ..add(HttpHeaders.setCookieHeader, 's2=2');
 
       final headers = Headers(clientRequest.headers);
       expect(headers.has('x-multi'), isTrue);
       expect(headers.get('x-multi'), 'one, two');
       expect(headers.get('missing'), isNull);
+      expect(headers.getSetCookie(), ['s1=1', 's2=2']);
+      final testedNames = {'set-cookie', 'x-a', 'x-b', 'x-multi'};
+      final testedEntries = headers
+          .where((entry) => testedNames.contains(entry.key))
+          .toList();
+      expect(testedEntries.map((entry) => '${entry.key}:${entry.value}'), [
+        'set-cookie:s1=1',
+        'set-cookie:s2=2',
+        'x-a:a1, a2',
+        'x-b:b1',
+        'x-multi:one, two',
+      ]);
+      expect(headers.keys().where(testedNames.contains).toList(), [
+        'set-cookie',
+        'set-cookie',
+        'x-a',
+        'x-b',
+        'x-multi',
+      ]);
+      expect(
+        headers.values().toList(),
+        containsAllInOrder(['s1=1', 's2=2', 'a1, a2', 'b1', 'one, two']),
+      );
 
       final clientResponseFuture = clientRequest.close();
       final serverRequest = await serverRequestFuture;

--- a/test/headers_test.dart
+++ b/test/headers_test.dart
@@ -23,7 +23,7 @@ void main() {
             .entries()
             .where((entry) => entry.key == 'accept')
             .map((entry) => entry.value),
-        ['application/json', 'text/plain'],
+        ['application/json, text/plain'],
       );
       expect(headers.get('accept'), 'application/json, text/plain');
     });
@@ -64,23 +64,35 @@ void main() {
             .entries()
             .where((entry) => entry.key == 'x-a')
             .map((entry) => entry.value),
-        ['1', '2'],
+        ['1, 2'],
       );
       expect(headers.map((entry) => '${entry.key}:${entry.value}').toList(), [
-        'x-a:1',
-        'x-a:2',
+        'x-a:1, 2',
         'x-b:3',
       ]);
     });
 
-    test('keys and values are normalized and deterministic', () {
+    test('iteration sorts and combines according to Fetch semantics', () {
       final headers = Headers()
-        ..append('X-A', '1')
-        ..append('x-a', '2')
-        ..append('X-B', '3');
+        ..append('X-B', 'b1')
+        ..append('X-A', 'a1')
+        ..append('x-a', 'a2')
+        ..append('Set-Cookie', 's1=1')
+        ..append('set-cookie', 's2=2');
 
-      expect(headers.keys().toList(), ['x-a', 'x-b']);
-      expect(headers.values().toList(), ['1', '2', '3']);
+      expect(headers.map((entry) => '${entry.key}:${entry.value}').toList(), [
+        'set-cookie:s1=1',
+        'set-cookie:s2=2',
+        'x-a:a1, a2',
+        'x-b:b1',
+      ]);
+      expect(headers.keys().toList(), [
+        'set-cookie',
+        'set-cookie',
+        'x-a',
+        'x-b',
+      ]);
+      expect(headers.values().toList(), ['s1=1', 's2=2', 'a1, a2', 'b1']);
     });
 
     test('delete removes all values', () {


### PR DESCRIPTION
## Summary

- align native `Headers` iteration with Fetch `sort and combine` behavior
- make `dart:io` `HttpHeaders` wrappers expose the same combined iteration shape
- update regression tests for repeated non-cookie headers, repeated `set-cookie`, keys, values, and default iteration

## Root Cause

Native and IO `Headers.entries()` exposed raw header lists. Fetch exposes iterable `Headers` value pairs after sorting and combining: repeated non-`set-cookie` headers are joined with `, `, while repeated `set-cookie` values remain separate entries.

## Runtime Check

Confirmed the target behavior against Node v26.0.0 and Chrome 149.0.7827.116. Bun 1.3.14 matches the combine/preserve behavior but differs in ordering, so this change follows Fetch/Chrome/Node ordering.

Closes #37

## Validation

- `dart analyze`
- `dart test test/headers_test.dart test/headers_io_test.dart`
- `dart test`
