### PR TITLE
fix(fetch): set body-derived content type defaults

### DIFF
--- a/lib/src/fetch/body.dart
+++ b/lib/src/fetch/body.dart
@@ -36,8 +36,7 @@ const _urlEncodedUtf8 = 'application/x-www-form-urlencoded;charset=UTF-8';
 
 /// Native detached body implementation.
 ///
-/// This is the shared body baseline that web/io implementations can align to,
-/// but it is intentionally not wired into the existing fetch types yet.
+/// This is the shared body baseline that web/io implementations align to.
 class Body extends Stream<Uint8List> {
   Body._({
     block.Block? blockHost,

--- a/lib/src/fetch/body.dart
+++ b/lib/src/fetch/body.dart
@@ -31,54 +31,78 @@ import 'url_search_params.dart';
 /// inputs before materialization.
 typedef BodyInit = Object?;
 
+const _textPlainUtf8 = 'text/plain;charset=UTF-8';
+const _urlEncodedUtf8 = 'application/x-www-form-urlencoded;charset=UTF-8';
+
 /// Native detached body implementation.
 ///
 /// This is the shared body baseline that web/io implementations can align to,
 /// but it is intentionally not wired into the existing fetch types yet.
 class Body extends Stream<Uint8List> {
-  Body._({block.Block? blockHost, Stream<Uint8List>? streamHost})
-    : assert(blockHost != null || streamHost != null),
-      _blockHost = blockHost,
-      _streamHost = streamHost;
+  Body._({
+    block.Block? blockHost,
+    Stream<Uint8List>? streamHost,
+    this.contentType,
+  }) : assert(blockHost != null || streamHost != null),
+       _blockHost = blockHost,
+       _streamHost = streamHost;
 
   factory Body([BodyInit? init]) {
-    return switch (init) {
-      null => Body._(blockHost: block.Block(const [])),
-      final Body body => body.clone(),
-      final String text => Body._(
-        blockHost: block.Block([text], type: 'text/plain;charset=utf-8'),
-      ),
-      final Uint8List bytes => Body._(blockHost: block.Block([bytes])),
-      final ByteBuffer buffer => Body._(
-        blockHost: block.Block([buffer.asUint8List()]),
-      ),
-      final List<int> bytes => Body._(blockHost: block.Block([bytes])),
-      final Blob blob => Body._(blockHost: blob),
-      final block.Block blockHost => Body._(blockHost: blockHost),
-      final URLSearchParams params => Body._(
-        blockHost: block.Block([
-          params.toString(),
-        ], type: 'application/x-www-form-urlencoded;charset=utf-8'),
-      ),
-      final FormData formData => Body._(
-        streamHost: formData.encodeMultipart().stream,
-      ),
-      final Stream<List<int>> stream => Body._(
-        streamHost: stream.map(
-          (chunk) => chunk is Uint8List ? chunk : Uint8List.fromList(chunk),
-        ),
-      ),
-      _ => throw ArgumentError.value(
-        init,
-        'init',
-        'Unsupported body type: ${init.runtimeType}',
-      ),
-    };
+    switch (init) {
+      case null:
+        return Body._(blockHost: block.Block(const []));
+      case final Body body:
+        return body.clone();
+      case final String text:
+        return Body._(
+          blockHost: block.Block([text], type: _textPlainUtf8),
+          contentType: _textPlainUtf8,
+        );
+      case final Uint8List bytes:
+        return Body._(blockHost: block.Block([bytes]));
+      case final ByteBuffer buffer:
+        return Body._(blockHost: block.Block([buffer.asUint8List()]));
+      case final List<int> bytes:
+        return Body._(blockHost: block.Block([Uint8List.fromList(bytes)]));
+      case final Blob blob:
+        return Body._(blockHost: blob, contentType: _contentType(blob.type));
+      case final block.Block blockHost:
+        return Body._(
+          blockHost: blockHost,
+          contentType: _contentType(blockHost.type),
+        );
+      case final URLSearchParams params:
+        return Body._(
+          blockHost: block.Block([params.toString()], type: _urlEncodedUtf8),
+          contentType: _urlEncodedUtf8,
+        );
+      case final FormData formData:
+        final encoded = formData.encodeMultipart();
+        return Body._(
+          streamHost: encoded.stream,
+          contentType: encoded.contentType,
+        );
+      case final Stream<List<int>> stream:
+        return Body._(
+          streamHost: stream.map(
+            (chunk) => chunk is Uint8List ? chunk : Uint8List.fromList(chunk),
+          ),
+        );
+      default:
+        throw ArgumentError.value(
+          init,
+          'init',
+          'Unsupported body type: ${init.runtimeType}',
+        );
+    }
   }
 
   final block.Block? _blockHost;
   Stream<Uint8List>? _streamHost;
   bool _used = false;
+
+  /// The body-derived media type, when extracting the body produced one.
+  final String? contentType;
 
   Stream<Uint8List> get stream async* {
     final blockHost = _blockHost;
@@ -139,14 +163,14 @@ class Body extends Stream<Uint8List> {
 
     final blockHost = _blockHost;
     if (blockHost != null) {
-      return Body._(blockHost: blockHost);
+      return Body._(blockHost: blockHost, contentType: contentType);
     }
 
     final streamHost = _streamHost;
     if (streamHost != null) {
       final (left, right) = streamTee(streamHost);
       _streamHost = left;
-      return Body._(streamHost: right);
+      return Body._(streamHost: right, contentType: contentType);
     }
 
     throw StateError('Body has no host.');
@@ -174,4 +198,6 @@ class Body extends Stream<Uint8List> {
 
     _used = true;
   }
+
+  static String? _contentType(String type) => type.isEmpty ? null : type;
 }

--- a/lib/src/fetch/request.io.dart
+++ b/lib/src/fetch/request.io.dart
@@ -229,26 +229,34 @@ class Request implements native.Request {
   @override
   Request clone() {
     final method = this.method;
-    final body = method.allowsRequestBody ? this.body : null;
-    return Request(
-      native.Request(
-        url,
-        native.RequestInit(
-          method: method,
-          headers: io_headers.Headers(headers),
-          body: body?.clone(),
-          referrer: referrer,
-          referrerPolicy: referrerPolicy,
-          mode: mode,
-          credentials: credentials,
-          cache: cache,
-          redirect: redirect,
-          integrity: integrity,
-          keepalive: keepalive,
-          duplex: duplex,
+    native.RequestInit init({BodyInit? body}) {
+      return native.RequestInit(
+        method: method,
+        headers: io_headers.Headers(headers),
+        body: body,
+        referrer: referrer,
+        referrerPolicy: referrerPolicy,
+        mode: mode,
+        credentials: credentials,
+        cache: cache,
+        redirect: redirect,
+        integrity: integrity,
+        keepalive: keepalive,
+        duplex: duplex,
+      );
+    }
+
+    return switch (_host) {
+      final NativeRequestHost host => Request(
+        native.Request(host.value, init()),
+      ),
+      HttpRequestHost() => Request(
+        native.Request(
+          url,
+          init(body: method.allowsRequestBody ? body?.clone() : null),
         ),
       ),
-    );
+    };
   }
 
   static native.Request _toNativeRequest(

--- a/lib/src/fetch/request.io.dart
+++ b/lib/src/fetch/request.io.dart
@@ -281,16 +281,11 @@ class Request implements native.Request {
     native.RequestInit? init,
   ) {
     final method = init?.method ?? request.method;
-    final body = init?.body == null
-        ? _bodyFromWrappedRequest(request, method)
-        : null;
-
-    return native.Request(
-      request.url,
-      native.RequestInit(
+    native.RequestInit requestInit({BodyInit? body}) {
+      return native.RequestInit(
         method: method,
         headers: init?.headers ?? io_headers.Headers(request.headers),
-        body: init?.body ?? body,
+        body: body,
         referrer: init?.referrer ?? request.referrer,
         referrerPolicy: init?.referrerPolicy ?? request.referrerPolicy,
         mode: init?.mode ?? request.mode,
@@ -300,8 +295,23 @@ class Request implements native.Request {
         integrity: init?.integrity ?? request.integrity,
         keepalive: init?.keepalive ?? request.keepalive,
         duplex: init?.duplex ?? request.duplex,
-      ),
-    );
+      );
+    }
+
+    if (init?.body == null) {
+      switch (request._host) {
+        case final NativeRequestHost host:
+          return native.Request(host.value, requestInit());
+        case HttpRequestHost():
+          break;
+      }
+    }
+
+    final body = init?.body == null
+        ? _bodyFromWrappedRequest(request, method)
+        : null;
+
+    return native.Request(request.url, requestInit(body: init?.body ?? body));
   }
 
   static Body? _bodyFromWrappedRequest(Request request, HttpMethod method) {

--- a/lib/src/fetch/request.js.dart
+++ b/lib/src/fetch/request.js.dart
@@ -315,14 +315,12 @@ class Request implements native.Request {
     Request request,
     native.RequestInit? init,
   ) {
-    final body = init?.body == null ? request.body : null;
-
-    return native.Request(
-      request.url,
-      native.RequestInit(
-        method: init?.method ?? request.method,
+    final method = init?.method ?? request.method;
+    native.RequestInit requestInit({BodyInit? body}) {
+      return native.RequestInit(
+        method: method,
         headers: init?.headers ?? js_headers.Headers(request.headers),
-        body: init?.body ?? body?.clone(),
+        body: body,
         referrer: init?.referrer ?? request.referrer,
         referrerPolicy: init?.referrerPolicy ?? request.referrerPolicy,
         mode: init?.mode ?? request.mode,
@@ -332,7 +330,23 @@ class Request implements native.Request {
         integrity: init?.integrity ?? request.integrity,
         keepalive: init?.keepalive ?? request.keepalive,
         duplex: init?.duplex ?? request.duplex,
-      ),
+      );
+    }
+
+    if (init?.body == null) {
+      switch (request._host) {
+        case final NativeRequestHost host:
+          return native.Request(host.value, requestInit());
+        case WebRequestHost():
+          break;
+      }
+    }
+
+    final body = init?.body == null ? request.body : null;
+
+    return native.Request(
+      request.url,
+      requestInit(body: init?.body ?? body?.clone()),
     );
   }
 

--- a/lib/src/fetch/request.js.dart
+++ b/lib/src/fetch/request.js.dart
@@ -290,7 +290,9 @@ class Request implements native.Request {
     }
 
     return switch (_host) {
-      final WebRequestHost host => Request(host.value.clone()),
+      final WebRequestHost host => Request(
+        _nativeRequestFromWebRequest(host.value.clone(), init()),
+      ),
       final NativeRequestHost host => Request(
         native.Request(host.value, init()),
       ),

--- a/lib/src/fetch/request.js.dart
+++ b/lib/src/fetch/request.js.dart
@@ -272,9 +272,28 @@ class Request implements native.Request {
 
   @override
   Request clone() {
+    native.RequestInit init({BodyInit? body}) {
+      return native.RequestInit(
+        method: method,
+        headers: js_headers.Headers(headers),
+        body: body,
+        referrer: referrer,
+        referrerPolicy: referrerPolicy,
+        mode: mode,
+        credentials: credentials,
+        cache: cache,
+        redirect: redirect,
+        integrity: integrity,
+        keepalive: keepalive,
+        duplex: duplex,
+      );
+    }
+
     return switch (_host) {
       final WebRequestHost host => Request(host.value.clone()),
-      final NativeRequestHost host => Request(host.value.clone()),
+      final NativeRequestHost host => Request(
+        native.Request(host.value, init()),
+      ),
     };
   }
 

--- a/lib/src/fetch/request.native.dart
+++ b/lib/src/fetch/request.native.dart
@@ -229,11 +229,10 @@ class Request {
 
   Request clone() {
     return Request(
-      url,
+      this,
       RequestInit(
         method: method,
         headers: Headers(headers),
-        body: body?.clone(),
         referrer: referrer,
         referrerPolicy: referrerPolicy,
         mode: mode,

--- a/lib/src/fetch/request.native.dart
+++ b/lib/src/fetch/request.native.dart
@@ -134,12 +134,6 @@ class Request {
 
   Request._(_RequestInput input, [RequestInit? init])
     : method = _methodFromInput(input, init?.method),
-      headers = _headersFromInput(input, init?.headers),
-      body = _bodyFromInput(
-        input,
-        init?.body,
-        _methodFromInput(input, init?.method),
-      ),
       cache = _cacheFromInput(input, init?.cache),
       credentials = _credentialsFromInput(input, init?.credentials),
       destination = _destinationFromInput(input),
@@ -151,9 +145,20 @@ class Request {
       redirect = _redirectFromInput(input, init?.redirect),
       referrer = _referrerFromInput(input, init?.referrer),
       referrerPolicy = _referrerPolicyFromInput(input, init?.referrerPolicy),
-      url = _urlFromInput(input);
-  final Headers headers;
-  final Body? body;
+      url = _urlFromInput(input) {
+    _headers = _headersFromInput(input, init?.headers);
+    _body = _bodyFromInput(input, init?.body, method);
+    if (init?.body != null) {
+      _appendContentTypeFromBody(headers, body);
+    }
+  }
+  late final Headers _headers;
+  late final Body? _body;
+
+  Headers get headers => _headers;
+
+  Body? get body => _body;
+
   final RequestCache cache;
   final RequestCredentials credentials;
   final String destination;
@@ -267,6 +272,15 @@ class Request {
       _validateRequestBodyMethod(method);
     }
     return body?.clone();
+  }
+
+  static void _appendContentTypeFromBody(Headers headers, Body? body) {
+    final contentType = body?.contentType;
+    if (contentType == null || headers.has('content-type')) {
+      return;
+    }
+
+    headers.set('content-type', contentType);
   }
 
   static RequestCache _cacheFromInput(_RequestInput input, RequestCache? init) {

--- a/lib/src/fetch/request.native.dart
+++ b/lib/src/fetch/request.native.dart
@@ -146,11 +146,12 @@ class Request {
       referrer = _referrerFromInput(input, init?.referrer),
       referrerPolicy = _referrerPolicyFromInput(input, init?.referrerPolicy),
       url = _urlFromInput(input) {
-    _headers = _headersFromInput(input, init?.headers);
-    _body = _bodyFromInput(input, init?.body, method);
-    if (init?.body != null) {
-      _appendContentTypeFromBody(headers, body);
-    }
+    final body = _bodyFromInput(input, init?.body, method);
+    final headers = _headersFromInput(input, init?.headers);
+    _headers = init?.body == null
+        ? headers
+        : _headersWithContentTypeFromBody(headers, body);
+    _body = body;
   }
   late final Headers _headers;
   late final Body? _body;
@@ -274,13 +275,13 @@ class Request {
     return body?.clone();
   }
 
-  static void _appendContentTypeFromBody(Headers headers, Body? body) {
+  static Headers _headersWithContentTypeFromBody(Headers headers, Body? body) {
     final contentType = body?.contentType;
     if (contentType == null || headers.has('content-type')) {
-      return;
+      return headers;
     }
 
-    headers.set('content-type', contentType);
+    return Headers(headers.entries())..set('content-type', contentType);
   }
 
   static RequestCache _cacheFromInput(_RequestInput input, RequestCache? init) {

--- a/lib/src/fetch/response.native.dart
+++ b/lib/src/fetch/response.native.dart
@@ -32,8 +32,10 @@ class Response {
   factory Response([BodyInit? body, ResponseInit? init]) {
     final status = _validateStatus(init?.status ?? HttpStatus.ok);
     final responseBody = _bodyFromInit(body, status);
-    final headers = _headersFromInit(init?.headers);
-    _appendContentTypeFromBody(headers, responseBody);
+    final headers = _headersWithContentTypeFromBody(
+      _headersFromInit(init?.headers),
+      responseBody,
+    );
     return Response._internal(
       body: responseBody,
       headers: headers,
@@ -198,13 +200,13 @@ class Response {
     };
   }
 
-  static void _appendContentTypeFromBody(Headers headers, Body? body) {
+  static Headers _headersWithContentTypeFromBody(Headers headers, Body? body) {
     final contentType = body?.contentType;
     if (contentType == null || headers.has('content-type')) {
-      return;
+      return headers;
     }
 
-    headers.set('content-type', contentType);
+    return Headers(headers.entries())..set('content-type', contentType);
   }
 
   static int _validateStatus(int status) {

--- a/lib/src/fetch/response.native.dart
+++ b/lib/src/fetch/response.native.dart
@@ -31,9 +31,12 @@ class ResponseInit {
 class Response {
   factory Response([BodyInit? body, ResponseInit? init]) {
     final status = _validateStatus(init?.status ?? HttpStatus.ok);
+    final responseBody = _bodyFromInit(body, status);
+    final headers = _headersFromInit(init?.headers);
+    _appendContentTypeFromBody(headers, responseBody);
     return Response._internal(
-      body: _bodyFromInit(body, status),
-      headers: _headersFromInit(init?.headers),
+      body: responseBody,
+      headers: headers,
       ok: HttpStatus.isSuccess(status),
       redirected: false,
       status: status,
@@ -193,6 +196,15 @@ class Response {
       null => Headers(),
       _ => Headers(init),
     };
+  }
+
+  static void _appendContentTypeFromBody(Headers headers, Body? body) {
+    final contentType = body?.contentType;
+    if (contentType == null || headers.has('content-type')) {
+      return;
+    }
+
+    headers.set('content-type', contentType);
   }
 
   static int _validateStatus(int status) {

--- a/test/body_test.dart
+++ b/test/body_test.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 
 import 'package:block/block.dart' as block;
 import 'package:ht/src/fetch/body.dart';
+import 'package:ht/src/fetch/form_data.native.dart';
 import 'package:ht/src/fetch/url_search_params.dart';
 import 'package:test/test.dart';
 
@@ -34,6 +35,26 @@ void main() {
       expect(await body.text(), 'a=1&b=2');
     });
 
+    test('exposes body-derived content type', () {
+      final params = URLSearchParams({'a': '1'});
+      final formData = FormData()..append('a', Multipart.text('1'));
+
+      expect(Body('hello').contentType, 'text/plain;charset=UTF-8');
+      expect(
+        Body(params).contentType,
+        'application/x-www-form-urlencoded;charset=UTF-8',
+      );
+      expect(
+        Body(block.Block(<Object>['x'], type: 'text/plain')).contentType,
+        'text/plain',
+      );
+      expect(
+        Body(formData).contentType,
+        startsWith('multipart/form-data; boundary='),
+      );
+      expect(Body([1, 2, 3]).contentType, isNull);
+    });
+
     test('block bodies can be converted back to Blob', () async {
       final body = Body(block.Block(<Object>['payload'], type: 'text/plain'));
       final blob = await body.blob();
@@ -41,6 +62,12 @@ void main() {
       expect(blob.type, 'text/plain');
       expect(await blob.text(), 'payload');
       expect(body.bodyUsed, isTrue);
+    });
+
+    test('list byte bodies decode as bytes', () async {
+      final body = Body([1, 2, 3]);
+
+      expect(await body.bytes(), [1, 2, 3]);
     });
 
     test('clone tees unread stream bodies', () async {

--- a/test/request_io_test.dart
+++ b/test/request_io_test.dart
@@ -45,6 +45,44 @@ void main() {
       );
     });
 
+    test('copies raw HttpHeaders before appending body content-type', () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(server.close);
+      final port = server.port;
+
+      final requestFuture = server.first;
+
+      final client = HttpClient();
+      addTearDown(client.close);
+
+      final clientRequest = await client.post(
+        InternetAddress.loopbackIPv4.host,
+        port,
+        '/headers-copy',
+      );
+      final clientResponseFuture = clientRequest.close();
+
+      final httpRequest = await requestFuture;
+      final request = native.Request(
+        'https://example.com/text',
+        native.RequestInit(
+          method: HttpMethod.post,
+          headers: httpRequest.headers,
+          body: 'hello',
+        ),
+      );
+
+      expect(request.headers.get('content-type'), 'text/plain;charset=UTF-8');
+      expect(httpRequest.headers[HttpHeaders.contentTypeHeader], isNull);
+
+      httpRequest.response
+        ..statusCode = HttpStatus.noContent
+        ..close();
+
+      final clientResponse = await clientResponseFuture;
+      await clientResponse.drain<void>();
+    });
+
     test('applies init overrides when cloning from wrapped requests', () async {
       final upstream = io_request.Request(
         native.Request(

--- a/test/request_io_test.dart
+++ b/test/request_io_test.dart
@@ -83,6 +83,22 @@ void main() {
       await clientResponse.drain<void>();
     });
 
+    test('clone preserves deleted body-derived content-type', () async {
+      final request = io_request.Request(
+        'https://example.com/clone',
+        native.RequestInit(method: HttpMethod.post, body: 'hello'),
+      );
+      expect(request.headers.get('content-type'), 'text/plain;charset=UTF-8');
+
+      request.headers.delete('content-type');
+      final clone = request.clone();
+
+      expect(request.headers.get('content-type'), isNull);
+      expect(clone.headers.get('content-type'), isNull);
+      expect(await request.text(), 'hello');
+      expect(await clone.text(), 'hello');
+    });
+
     test('applies init overrides when cloning from wrapped requests', () async {
       final upstream = io_request.Request(
         native.Request(

--- a/test/request_io_test.dart
+++ b/test/request_io_test.dart
@@ -6,6 +6,7 @@ import 'dart:io';
 import 'package:ht/src/core/http_method.dart';
 import 'package:ht/src/fetch/request.io.dart' as io_request;
 import 'package:ht/src/fetch/request.native.dart' as native;
+import 'package:ht/src/fetch/url_search_params.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -19,6 +20,29 @@ void main() {
       );
 
       expect(identical(request.body, request.body), isTrue);
+    });
+
+    test('sets default content-type for native construction body init', () {
+      final textRequest = io_request.Request(
+        'https://example.com/text',
+        native.RequestInit(method: HttpMethod.post, body: 'hello'),
+      );
+      expect(
+        textRequest.headers.get('content-type'),
+        'text/plain;charset=UTF-8',
+      );
+
+      final paramsRequest = io_request.Request(
+        'https://example.com/form',
+        native.RequestInit(
+          method: HttpMethod.post,
+          body: URLSearchParams({'a': '1'}),
+        ),
+      );
+      expect(
+        paramsRequest.headers.get('content-type'),
+        'application/x-www-form-urlencoded;charset=UTF-8',
+      );
     });
 
     test('applies init overrides when cloning from wrapped requests', () async {

--- a/test/request_io_test.dart
+++ b/test/request_io_test.dart
@@ -99,6 +99,25 @@ void main() {
       expect(await clone.text(), 'hello');
     });
 
+    test('init override preserves deleted body-derived content-type', () async {
+      final request = io_request.Request(
+        'https://example.com/rebuild',
+        native.RequestInit(method: HttpMethod.post, body: 'hello'),
+      );
+      request.headers.delete('content-type');
+
+      final rebuilt = io_request.Request(
+        request,
+        native.RequestInit(cache: native.RequestCache.noStore),
+      );
+
+      expect(rebuilt.cache, native.RequestCache.noStore);
+      expect(request.headers.get('content-type'), isNull);
+      expect(rebuilt.headers.get('content-type'), isNull);
+      expect(await request.text(), 'hello');
+      expect(await rebuilt.text(), 'hello');
+    });
+
     test('applies init overrides when cloning from wrapped requests', () async {
       final upstream = io_request.Request(
         native.Request(

--- a/test/request_js_test.dart
+++ b/test/request_js_test.dart
@@ -57,6 +57,22 @@ void main() {
       expect(request.headers.get('content-type'), 'text/plain;charset=UTF-8');
     });
 
+    test('clone preserves deleted body-derived content-type', () async {
+      final request = Request(
+        'https://example.com/clone',
+        native.RequestInit(method: HttpMethod.post, body: 'hello'),
+      );
+      expect(request.headers.get('content-type'), 'text/plain;charset=UTF-8');
+
+      request.headers.delete('content-type');
+      final clone = request.clone();
+
+      expect(request.headers.get('content-type'), isNull);
+      expect(clone.headers.get('content-type'), isNull);
+      expect(await request.text(), 'hello');
+      expect(await clone.text(), 'hello');
+    });
+
     test('applies init overrides when cloning from wrapped requests', () async {
       final upstream = Request(
         web.Request(

--- a/test/request_js_test.dart
+++ b/test/request_js_test.dart
@@ -73,6 +73,25 @@ void main() {
       expect(await clone.text(), 'hello');
     });
 
+    test('init override preserves deleted body-derived content-type', () async {
+      final request = Request(
+        'https://example.com/rebuild',
+        native.RequestInit(method: HttpMethod.post, body: 'hello'),
+      );
+      request.headers.delete('content-type');
+
+      final rebuilt = Request(
+        request,
+        native.RequestInit(cache: native.RequestCache.noStore),
+      );
+
+      expect(rebuilt.cache, native.RequestCache.noStore);
+      expect(request.headers.get('content-type'), isNull);
+      expect(rebuilt.headers.get('content-type'), isNull);
+      expect(await request.text(), 'hello');
+      expect(await rebuilt.text(), 'hello');
+    });
+
     test('applies init overrides when cloning from wrapped requests', () async {
       final upstream = Request(
         web.Request(

--- a/test/request_js_test.dart
+++ b/test/request_js_test.dart
@@ -48,6 +48,15 @@ void main() {
       expect(request.bodyUsed, isTrue);
     });
 
+    test('sets default content-type for native construction body init', () {
+      final request = Request(
+        'https://example.com/text',
+        native.RequestInit(method: HttpMethod.post, body: 'hello'),
+      );
+
+      expect(request.headers.get('content-type'), 'text/plain;charset=UTF-8');
+    });
+
     test('applies init overrides when cloning from wrapped requests', () async {
       final upstream = Request(
         web.Request(

--- a/test/request_js_test.dart
+++ b/test/request_js_test.dart
@@ -73,6 +73,33 @@ void main() {
       expect(await clone.text(), 'hello');
     });
 
+    test('clone preserves web host header mutations', () async {
+      final request = Request(
+        web.Request(
+          'https://example.com/web-clone'.toJS,
+          web.RequestInit(
+            method: 'POST',
+            headers:
+                {'content-type': 'text/plain', 'x-id': '1'}.jsify()!
+                    as web.HeadersInit,
+            body: 'hello'.toJS,
+          ),
+        ),
+      );
+      request.headers
+        ..delete('content-type')
+        ..set('x-id', '2');
+
+      final clone = request.clone();
+
+      expect(request.headers.get('content-type'), isNull);
+      expect(request.headers.get('x-id'), '2');
+      expect(clone.headers.get('content-type'), isNull);
+      expect(clone.headers.get('x-id'), '2');
+      expect(await request.text(), 'hello');
+      expect(await clone.text(), 'hello');
+    });
+
     test('init override preserves deleted body-derived content-type', () async {
       final request = Request(
         'https://example.com/rebuild',

--- a/test/request_native_test.dart
+++ b/test/request_native_test.dart
@@ -5,6 +5,7 @@ import 'package:ht/src/fetch/blob.dart';
 import 'package:ht/src/fetch/form_data.native.dart';
 import 'package:ht/src/fetch/headers.dart';
 import 'package:ht/src/fetch/request.native.dart';
+import 'package:ht/src/fetch/url_search_params.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -123,6 +124,86 @@ void main() {
       final blob = await request.blob();
       expect(blob.type, 'application/custom');
       expect(await blob.text(), 'hello');
+    });
+
+    test('sets default content-type from body init', () async {
+      final textRequest = Request(
+        'https://example.com/text',
+        RequestInit(method: HttpMethod.post, body: 'hello'),
+      );
+      expect(
+        textRequest.headers.get('content-type'),
+        'text/plain;charset=UTF-8',
+      );
+
+      final paramsRequest = Request(
+        'https://example.com/form',
+        RequestInit(
+          method: HttpMethod.post,
+          body: URLSearchParams({'a': '1', 'b': '2'}),
+        ),
+      );
+      expect(
+        paramsRequest.headers.get('content-type'),
+        'application/x-www-form-urlencoded;charset=UTF-8',
+      );
+
+      final blobRequest = Request(
+        'https://example.com/blob',
+        RequestInit(
+          method: HttpMethod.post,
+          body: Blob(<BlobPart>['hello'], 'text/plain'),
+        ),
+      );
+      expect(blobRequest.headers.get('content-type'), 'text/plain');
+
+      final emptyBlobRequest = Request(
+        'https://example.com/blob',
+        RequestInit(method: HttpMethod.post, body: Blob(<BlobPart>['hello'])),
+      );
+      expect(emptyBlobRequest.headers.get('content-type'), isNull);
+
+      final formRequest = Request(
+        'https://example.com/multipart',
+        RequestInit(
+          method: HttpMethod.post,
+          body: FormData()..append('name', Multipart.text('alice')),
+        ),
+      );
+      expect(
+        formRequest.headers.get('content-type'),
+        startsWith('multipart/form-data; boundary='),
+      );
+      final formData = await formRequest.formData();
+      expect((formData.get('name')! as TextMultipart).value, 'alice');
+
+      final bytesRequest = Request(
+        'https://example.com/bytes',
+        RequestInit(method: HttpMethod.post, body: utf8.encode('hello')),
+      );
+      expect(bytesRequest.headers.get('content-type'), isNull);
+
+      final streamRequest = Request(
+        'https://example.com/stream',
+        RequestInit(
+          method: HttpMethod.post,
+          body: Stream<List<int>>.value(utf8.encode('hello')),
+        ),
+      );
+      expect(streamRequest.headers.get('content-type'), isNull);
+    });
+
+    test('preserves explicit content-type over body defaults', () {
+      final request = Request(
+        'https://example.com/text',
+        RequestInit(
+          method: HttpMethod.post,
+          headers: Headers({'content-type': 'application/custom'}),
+          body: 'hello',
+        ),
+      );
+
+      expect(request.headers.get('content-type'), 'application/custom');
     });
 
     test(

--- a/test/request_native_test.dart
+++ b/test/request_native_test.dart
@@ -297,6 +297,22 @@ void main() {
       expect(await clone.text(), 'hello world');
     });
 
+    test('clone preserves deleted body-derived content-type', () async {
+      final request = Request(
+        'https://example.com/clone',
+        RequestInit(method: HttpMethod.post, body: 'hello'),
+      );
+      expect(request.headers.get('content-type'), 'text/plain;charset=UTF-8');
+
+      request.headers.delete('content-type');
+      final clone = request.clone();
+
+      expect(request.headers.get('content-type'), isNull);
+      expect(clone.headers.get('content-type'), isNull);
+      expect(await request.text(), 'hello');
+      expect(await clone.text(), 'hello');
+    });
+
     test('clone fails after body has been consumed', () async {
       final request = Request(
         'https://example.com/clone',

--- a/test/response_io_test.dart
+++ b/test/response_io_test.dart
@@ -5,6 +5,7 @@ import 'dart:io' as io;
 
 import 'package:ht/src/fetch/response.io.dart';
 import 'package:ht/src/fetch/response.native.dart' as native;
+import 'package:ht/src/fetch/url_search_params.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -18,6 +19,20 @@ void main() {
       expect(clone.type, native.ResponseType.error);
       expect(clone.status, 0);
       expect(clone.ok, isFalse);
+    });
+
+    test('sets default content-type for native construction body init', () {
+      final textResponse = Response('hello');
+      expect(
+        textResponse.headers.get('content-type'),
+        'text/plain;charset=UTF-8',
+      );
+
+      final paramsResponse = Response(URLSearchParams({'a': '1'}));
+      expect(
+        paramsResponse.headers.get('content-type'),
+        'application/x-www-form-urlencoded;charset=UTF-8',
+      );
     });
 
     test('enforces native constructor invariants', () {

--- a/test/response_io_test.dart
+++ b/test/response_io_test.dart
@@ -35,6 +35,39 @@ void main() {
       );
     });
 
+    test('copies raw HttpHeaders before appending body content-type', () async {
+      final server = await io.HttpServer.bind(
+        io.InternetAddress.loopbackIPv4,
+        0,
+      );
+      addTearDown(server.close);
+
+      server.listen((request) {
+        request.response.headers.contentType = null;
+        request.response
+          ..statusCode = io.HttpStatus.noContent
+          ..close();
+      });
+
+      final client = io.HttpClient();
+      addTearDown(client.close);
+
+      final httpRequest = await client.getUrl(
+        Uri.parse('http://${server.address.host}:${server.port}/'),
+      );
+      final httpResponse = await httpRequest.close();
+
+      final response = native.Response(
+        'hello',
+        native.ResponseInit(headers: httpResponse.headers),
+      );
+
+      expect(response.headers.get('content-type'), 'text/plain;charset=UTF-8');
+      expect(httpResponse.headers[io.HttpHeaders.contentTypeHeader], isNull);
+
+      await httpResponse.drain<void>();
+    });
+
     test('enforces native constructor invariants', () {
       expect(
         () => Response(null, const native.ResponseInit(status: 199)),

--- a/test/response_js_test.dart
+++ b/test/response_js_test.dart
@@ -36,6 +36,12 @@ void main() {
       expect(response.bodyUsed, isTrue);
     });
 
+    test('sets default content-type for native construction body init', () {
+      final response = Response('hello');
+
+      expect(response.headers.get('content-type'), 'text/plain;charset=UTF-8');
+    });
+
     test('clone tees a wrapped web.Response body', () async {
       final upstream = web.Response('cloned body'.toJS);
 

--- a/test/response_native_test.dart
+++ b/test/response_native_test.dart
@@ -5,6 +5,7 @@ import 'package:ht/src/fetch/blob.dart';
 import 'package:ht/src/fetch/form_data.native.dart';
 import 'package:ht/src/fetch/headers.dart';
 import 'package:ht/src/fetch/response.native.dart';
+import 'package:ht/src/fetch/url_search_params.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -162,6 +163,53 @@ void main() {
       final blob = await response.blob();
       expect(blob.type, 'application/custom');
       expect(await blob.text(), 'hello');
+    });
+
+    test('sets default content-type from body init', () async {
+      final textResponse = Response('hello');
+      expect(
+        textResponse.headers.get('content-type'),
+        'text/plain;charset=UTF-8',
+      );
+
+      final paramsResponse = Response(URLSearchParams({'a': '1', 'b': '2'}));
+      expect(
+        paramsResponse.headers.get('content-type'),
+        'application/x-www-form-urlencoded;charset=UTF-8',
+      );
+
+      final blobResponse = Response(Blob(<BlobPart>['hello'], 'text/plain'));
+      expect(blobResponse.headers.get('content-type'), 'text/plain');
+
+      final emptyBlobResponse = Response(Blob(<BlobPart>['hello']));
+      expect(emptyBlobResponse.headers.get('content-type'), isNull);
+
+      final formResponse = Response(
+        FormData()..append('name', Multipart.text('alice')),
+      );
+      expect(
+        formResponse.headers.get('content-type'),
+        startsWith('multipart/form-data; boundary='),
+      );
+      final formData = await formResponse.formData();
+      expect((formData.get('name')! as TextMultipart).value, 'alice');
+
+      final bytesResponse = Response(utf8.encode('hello'));
+      expect(bytesResponse.headers.get('content-type'), isNull);
+
+      final streamResponse = Response(
+        Stream<List<int>>.value(utf8.encode('hello')),
+      );
+      expect(streamResponse.headers.get('content-type'), isNull);
+    });
+
+    test('preserves explicit content-type over body defaults', () {
+      final response = Response(
+        'hello',
+        ResponseInit(headers: Headers({'content-type': 'application/custom'})),
+      );
+
+      expect(response.headers.get('content-type'), 'application/custom');
     });
 
     test(


### PR DESCRIPTION
## Summary

- preserve body-derived media type metadata on `Body`
- set default `Content-Type` in `Request` and `Response` constructors when body init provides a type and callers omit the header
- cover native, IO, and JS wrapper construction paths for string, URLSearchParams, Blob, FormData, byte, and stream bodies

## Root Cause

`Body` created typed block-backed bodies for string, URLSearchParams, Blob, and block inputs, but `Request` and `Response` built headers separately and never appended the extracted body type. FormData also lost its multipart content type when it was converted directly into a stream body.

## Notes

`Response.json()` is intentionally left unchanged for #40. Blob/File MIME normalization remains scoped to #39, so Blob-derived defaults use the current `Blob.type` value.

Closes #38

## Validation

- `dart analyze`
- `dart test test/body_test.dart test/request_native_test.dart test/response_native_test.dart test/request_io_test.dart test/response_io_test.dart`
- `dart test -p chrome test/request_js_test.dart test/response_js_test.dart`
- `dart test`
- `dart test -p vm -p node -p chrome`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Requests and responses now automatically set appropriate content-type headers based on body input types (e.g., `text/plain` for strings, `application/x-www-form-urlencoded` for form parameters, `multipart/form-data` for file uploads).
  * Content-type headers are now correctly preserved when cloning requests and responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->