### PR TITLE
fix(fetch): normalize blob and file MIME types

### DIFF
--- a/lib/src/fetch/blob.js.dart
+++ b/lib/src/fetch/blob.js.dart
@@ -11,7 +11,10 @@ class Blob extends native.Blob implements block.Block {
   Blob([
     Iterable<native.BlobPart> parts = const <native.BlobPart>[],
     String type = '',
-  ]) : super([_toBlock(parts, type)], type);
+  ]) : this._fromNormalized(parts, native.normalizeBlobType(type));
+
+  Blob._fromNormalized(Iterable<native.BlobPart> parts, String normalizedType)
+    : super([_toBlock(parts, normalizedType)], normalizedType);
 
   static block.Block _toBlock(Iterable<native.BlobPart> parts, String type) {
     return block.Block(_normalizeParts(parts), type: type);

--- a/lib/src/fetch/blob.native.dart
+++ b/lib/src/fetch/blob.native.dart
@@ -23,7 +23,7 @@ typedef BlobPart = Object;
 /// Native detached binary large object.
 class Blob implements block.Block {
   Blob([Iterable<BlobPart> parts = const <BlobPart>[], String type = ''])
-    : this._fromNormalized(_normalizeParts(parts), type);
+    : this._fromNormalized(_normalizeParts(parts), normalizeBlobType(type));
 
   Blob._fromNormalized(List<Object> parts, String normalizedType)
     : this._fromBlock(
@@ -60,10 +60,10 @@ class Blob implements block.Block {
 
   @override
   Blob slice(int start, [int? end, String? contentType]) {
-    contentType ??= '';
+    final normalizedContentType = normalizeBlobType(contentType ?? '');
     return Blob._fromBlock(
-      _host.slice(start, end, contentType),
-      type: contentType,
+      _host.slice(start, end, normalizedContentType),
+      type: normalizedContentType,
     );
   }
 
@@ -88,4 +88,25 @@ class Blob implements block.Block {
       ),
     };
   }
+}
+
+/// Normalizes Blob/File MIME type inputs using the File API rules.
+String normalizeBlobType(String type) {
+  StringBuffer? buffer;
+
+  for (var index = 0; index < type.length; index += 1) {
+    final unit = type.codeUnitAt(index);
+    if (unit < 0x20 || unit > 0x7E) {
+      return '';
+    }
+
+    if (unit >= 0x41 && unit <= 0x5A) {
+      buffer ??= StringBuffer(type.substring(0, index));
+      buffer.writeCharCode(unit + 0x20);
+    } else {
+      buffer?.writeCharCode(unit);
+    }
+  }
+
+  return buffer?.toString() ?? type;
 }

--- a/test/blob_io_test.dart
+++ b/test/blob_io_test.dart
@@ -6,6 +6,7 @@ import 'dart:io' as io;
 
 import 'package:ht/src/fetch/body.dart';
 import 'package:ht/src/fetch/blob.io.dart' as io_blob;
+import 'package:ht/src/fetch/file.dart' as fetch_file;
 import 'package:test/test.dart';
 
 void main() {
@@ -26,6 +27,30 @@ void main() {
       expect(blob.size, 11);
       expect(blob.type, 'text/plain');
       expect(await blob.text(), 'hello world');
+    });
+
+    test('normalizes MIME type inputs', () {
+      expect(
+        io_blob.Blob(<Object>['x'], 'TEXT/PLAIN;Charset=UTF-8').type,
+        'text/plain;charset=utf-8',
+      );
+      expect(io_blob.Blob(<Object>['x'], 'NOT A MIME').type, 'not a mime');
+      expect(io_blob.Blob(<Object>['x'], 'text/π').type, isEmpty);
+      expect(io_blob.Blob(<Object>['x'], 'text/plain\nx').type, isEmpty);
+
+      final blob = io_blob.Blob(<Object>['payload'], 'text/plain');
+      expect(blob.slice(0, 1).type, isEmpty);
+      expect(blob.slice(0, 1, 'TEXT/HTML').type, 'text/html');
+      expect(blob.slice(0, 1, 'text/π').type, isEmpty);
+
+      expect(
+        fetch_file.File(<Object>['x'], 'x.txt', type: 'TEXT/PLAIN').type,
+        'text/plain',
+      );
+      expect(
+        fetch_file.File(<Object>['x'], 'x.txt', type: 'text/π').type,
+        isEmpty,
+      );
     });
 
     test(

--- a/test/blob_js_test.dart
+++ b/test/blob_js_test.dart
@@ -5,6 +5,7 @@ import 'dart:js_interop';
 
 import 'package:ht/src/_internal/web_fetch_utils.dart' as web_fetch;
 import 'package:ht/src/fetch/blob.js.dart' as js;
+import 'package:ht/src/fetch/file.dart' as fetch_file;
 import 'package:test/test.dart';
 import 'package:web/web.dart' as web;
 
@@ -20,6 +21,30 @@ void main() {
 
       expect(blob.type, 'text/plain');
       expect(await blob.text(), 'hello world');
+    });
+
+    test('normalizes MIME type inputs', () {
+      expect(
+        js.Blob(<Object>['x'], 'TEXT/PLAIN;Charset=UTF-8').type,
+        'text/plain;charset=utf-8',
+      );
+      expect(js.Blob(<Object>['x'], 'NOT A MIME').type, 'not a mime');
+      expect(js.Blob(<Object>['x'], 'text/π').type, isEmpty);
+      expect(js.Blob(<Object>['x'], 'text/plain\nx').type, isEmpty);
+
+      final blob = js.Blob(<Object>['payload'], 'text/plain');
+      expect(blob.slice(0, 1).type, isEmpty);
+      expect(blob.slice(0, 1, 'TEXT/HTML').type, 'text/html');
+      expect(blob.slice(0, 1, 'text/π').type, isEmpty);
+
+      expect(
+        fetch_file.File(<Object>['x'], 'x.txt', type: 'TEXT/PLAIN').type,
+        'text/plain',
+      );
+      expect(
+        fetch_file.File(<Object>['x'], 'x.txt', type: 'text/π').type,
+        isEmpty,
+      );
     });
 
     test('accepts native web.File parts', () async {

--- a/test/blob_native_test.dart
+++ b/test/blob_native_test.dart
@@ -1,0 +1,34 @@
+@TestOn('vm')
+library;
+
+import 'package:ht/src/fetch/blob.native.dart' as native;
+import 'package:test/test.dart';
+
+void main() {
+  group('Blob (native)', () {
+    test('normalizes MIME type inputs', () {
+      expect(
+        native.Blob(<native.BlobPart>['x'], 'TEXT/PLAIN;Charset=UTF-8').type,
+        'text/plain;charset=utf-8',
+      );
+      expect(
+        native.Blob(<native.BlobPart>['x'], 'NOT A MIME').type,
+        'not a mime',
+      );
+      expect(native.Blob(<native.BlobPart>['x'], 'text/π').type, isEmpty);
+      expect(
+        native.Blob(<native.BlobPart>['x'], 'text/plain\nx').type,
+        isEmpty,
+      );
+    });
+
+    test('normalizes slice content type inputs', () {
+      final blob = native.Blob(<native.BlobPart>['payload'], 'text/plain');
+
+      expect(blob.slice(0, 1).type, isEmpty);
+      expect(blob.slice(0, 1, 'TEXT/HTML').type, 'text/html');
+      expect(blob.slice(0, 1, 'text/π').type, isEmpty);
+      expect(blob.slice(0, 1, 'text/plain\nx').type, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Normalize `Blob`, `File`, and `Blob.slice(..., contentType)` MIME type inputs using File API rules.
- Lowercase printable ASCII type strings and return an empty type when the input contains non-printable or non-ASCII characters.
- Keep JS-backed `Blob` host blocks aligned with the normalized `Blob.type` value.

## Root Cause

`ht` passed MIME type strings through to `package:block` verbatim. `package:block` is a byte block abstraction, not the File API semantics layer, so uppercase and invalid MIME type inputs leaked through `Blob.type`, `File.type`, and slice results.

## Validation

- `dart analyze`
- `dart test --reporter expanded`
- `dart test test/blob_native_test.dart test/blob_io_test.dart --reporter expanded`
- `dart test -p chrome test/blob_js_test.dart --reporter expanded`
- `dart test -p chrome test/blob_js_test.dart test/request_js_test.dart test/response_js_test.dart test/headers_js_test.dart test/url_search_params_js_test.dart test/_internal/web_fetch_utils_test.dart --reporter expanded`

Closes #39
Refs #36


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * MIME type normalization in Blob objects ensures consistent behavior across platforms
  * Invalid MIME types are properly handled as empty strings for reliability
  * Blob slice operations now correctly normalize content type parameters when provided

<!-- end of auto-generated comment: release notes by coderabbit.ai -->