### PR TITLE
feat(fetch): expose Body size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Next
 
+- Added `Body.size` for exposing known body byte lengths without consuming the
+  body.
+
 ## 0.5.0
 
 - BREAKING: `Request.method` and `RequestInit.method` now use `String` values

--- a/lib/src/fetch/body.dart
+++ b/lib/src/fetch/body.dart
@@ -41,8 +41,11 @@ class Body extends Stream<Uint8List> {
   Body._({
     block.Block? blockHost,
     Stream<Uint8List>? streamHost,
+    int? byteLength,
     this.contentType,
   }) : assert(blockHost != null || streamHost != null),
+       assert(byteLength == null || byteLength >= 0),
+       size = byteLength ?? blockHost?.size,
        _blockHost = blockHost,
        _streamHost = streamHost;
 
@@ -79,6 +82,7 @@ class Body extends Stream<Uint8List> {
         final encoded = formData.encodeMultipart();
         return Body._(
           streamHost: encoded.stream,
+          byteLength: encoded.contentLength,
           contentType: encoded.contentType,
         );
       case final Stream<List<int>> stream:
@@ -102,6 +106,11 @@ class Body extends Stream<Uint8List> {
 
   /// The body-derived media type, when extracting the body produced one.
   final String? contentType;
+
+  /// The byte length when it is known without consuming the body.
+  ///
+  /// Stream-backed bodies created from arbitrary [Stream] values return `null`.
+  final int? size;
 
   Stream<Uint8List> get stream async* {
     final blockHost = _blockHost;
@@ -169,7 +178,11 @@ class Body extends Stream<Uint8List> {
     if (streamHost != null) {
       final (left, right) = streamTee(streamHost);
       _streamHost = left;
-      return Body._(streamHost: right, contentType: contentType);
+      return Body._(
+        streamHost: right,
+        byteLength: size,
+        contentType: contentType,
+      );
     }
 
     throw StateError('Body has no host.');

--- a/test/body_test.dart
+++ b/test/body_test.dart
@@ -55,6 +55,32 @@ void main() {
       expect(Body([1, 2, 3]).contentType, isNull);
     });
 
+    test('exposes known byte size without consuming the body', () {
+      final params = URLSearchParams({'a': '1', 'b': '2'});
+      final formData = FormData()..append('a', Multipart.text('1'));
+      final formBody = Body(formData);
+
+      expect(Body().size, 0);
+      expect(Body('hello').size, 5);
+      expect(Body(Uint8List.fromList([1, 2, 3])).size, 3);
+      expect(Body(Uint8List(2).buffer).size, 2);
+      expect(Body([1, 2, 3, 4]).size, 4);
+      expect(
+        Body(block.Block(<Object>['payload'], type: 'text/plain')).size,
+        7,
+      );
+      expect(Body(params).size, 7);
+      expect(formBody.size, greaterThan(0));
+      expect(formBody.bodyUsed, isFalse);
+    });
+
+    test('reports null size for arbitrary stream bodies', () {
+      final body = Body(Stream<List<int>>.value(utf8.encode('stream')));
+
+      expect(body.size, isNull);
+      expect(body.bodyUsed, isFalse);
+    });
+
     test('block bodies can be converted back to Blob', () async {
       final body = Body(block.Block(<Object>['payload'], type: 'text/plain'));
       final blob = await body.blob();

--- a/test/public_api_surface_test.dart
+++ b/test/public_api_surface_test.dart
@@ -21,6 +21,7 @@ void main() {
     final file = File(<Object>[blob], 'hello.txt', type: 'text/plain');
     final form = FormData()..append('file', Multipart.blob(file));
     final multipart = form.encodeMultipart(boundary: 'api');
+    final body = Body('public');
     final blockBody = block.Block(<Object>['block-body'], type: 'text/plain');
 
     final request = Request(
@@ -41,6 +42,7 @@ void main() {
     expect(requestInit.method, 'POST');
     expect(requestInit.priority, RequestPriority.high);
     expect(responseInit.status, 200);
+    expect(body.size, 6);
     expect(request.headers.has('content-type'), isTrue);
     expect(await multipart.bytes(), isNotEmpty);
     expect(await response.text(), 'block-body');


### PR DESCRIPTION
## Summary

- Add `Body.size` as a public `int?` byte-length property.
- Preserve known sizes for `Block`-backed bodies and encoded `FormData` bodies without consuming them.
- Return `null` for arbitrary stream-backed bodies where the length is not known synchronously.

## Validation

- `dart format --output=none --set-exit-if-changed .`
- `dart analyze`
- `dart test -p vm -p node -p chrome`

No linked issue.