### PR TITLE
refactor(fetch): make Body extend Blob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Next
 
+- BREAKING: `Body` now extends the platform `Blob` implementation and implements
+  `Stream<Uint8List>` directly; use `body` as a stream or call `body.stream()`
+  instead of reading the previous `body.stream` getter.
 - Added `Body.size` for exposing known body byte lengths without consuming the
   body.
 - Fixed `Blob` byte snapshot semantics so byte-backed parts and read buffers are

--- a/lib/src/fetch/body.dart
+++ b/lib/src/fetch/body.dart
@@ -26,122 +26,96 @@ import 'url_search_params.dart';
 /// On IO, `dart:io File` values are supported as [Blob] parts. Wrap files in a
 /// [Blob] before passing them as [BodyInit], for example `Body(Blob([file]))`.
 ///
-/// Native bodies normalize supported inputs into a detached [block.Block]
-/// when possible. Platform implementations may accept additional host-backed
-/// inputs before materialization.
+/// Bodies normalize supported inputs into a detached [Blob] when
+/// possible. Platform implementations may accept additional host-backed inputs
+/// before materialization.
 typedef BodyInit = Object?;
 
 const _textPlainUtf8 = 'text/plain;charset=UTF-8';
 const _urlEncodedUtf8 = 'application/x-www-form-urlencoded;charset=UTF-8';
+const _defaultBlobChunkSize = 16 * 1024;
 
 /// Native detached body implementation.
 ///
 /// This is the shared body baseline that web/io implementations align to.
-class Body extends Stream<Uint8List> {
+class Body extends Blob with Stream<Uint8List> implements Stream<Uint8List> {
   Body._({
-    block.Block? blockHost,
+    Iterable<BlobPart> blobParts = const <BlobPart>[],
     Stream<Uint8List>? streamHost,
-    int? byteLength,
+    int? streamSize,
+    String type = '',
     this.contentType,
-  }) : assert(blockHost != null || streamHost != null),
-       assert(byteLength == null || byteLength >= 0),
-       size = byteLength ?? blockHost?.size,
-       _blockHost = blockHost,
-       _streamHost = streamHost;
+  }) : assert(streamSize == null || streamSize >= 0),
+       _streamHost = streamHost,
+       _streamSize = streamSize,
+       super(blobParts, type);
 
   factory Body([BodyInit? init]) {
-    switch (init) {
-      case null:
-        return Body._(blockHost: block.Block(const []));
-      case final Body body:
-        return body.clone();
-      case final String text:
-        return Body._(
-          blockHost: block.Block([text], type: _textPlainUtf8),
-          contentType: _textPlainUtf8,
-        );
-      case final Uint8List bytes:
-        return Body._(blockHost: block.Block([bytes]));
-      case final ByteBuffer buffer:
-        return Body._(blockHost: block.Block([buffer.asUint8List()]));
-      case final List<int> bytes:
-        return Body._(blockHost: block.Block([Uint8List.fromList(bytes)]));
-      case final Blob blob:
-        return Body._(blockHost: blob, contentType: _contentType(blob.type));
-      case final block.Block blockHost:
-        return Body._(
-          blockHost: blockHost,
-          contentType: _contentType(blockHost.type),
-        );
-      case final URLSearchParams params:
-        return Body._(
-          blockHost: block.Block([params.toString()], type: _urlEncodedUtf8),
-          contentType: _urlEncodedUtf8,
-        );
-      case final FormData formData:
-        final encoded = formData.encodeMultipart();
-        return Body._(
-          streamHost: encoded.stream,
-          byteLength: encoded.contentLength,
-          contentType: encoded.contentType,
-        );
-      case final Stream<List<int>> stream:
-        return Body._(
-          streamHost: stream.map(
-            (chunk) => chunk is Uint8List ? chunk : Uint8List.fromList(chunk),
-          ),
-        );
-      default:
-        throw ArgumentError.value(
-          init,
-          'init',
-          'Unsupported body type: ${init.runtimeType}',
-        );
-    }
+    return switch (init) {
+      final Body body => body.clone(),
+      final FormData formData => Body._fromFormData(formData),
+      final Stream<List<int>> stream => Body._fromStream(stream),
+      _ => Body._fromBlobInit(init),
+    };
   }
 
-  final block.Block? _blockHost;
   Stream<Uint8List>? _streamHost;
+  int? _streamSize;
   bool _used = false;
 
   /// The body-derived media type, when extracting the body produced one.
   final String? contentType;
 
-  /// The byte length when it is known without consuming the body.
-  ///
-  /// Stream-backed bodies created from arbitrary [Stream] values return `null`.
-  final int? size;
-
-  Stream<Uint8List> get stream async* {
-    final blockHost = _blockHost;
+  @override
+  int get size {
     final streamHost = _streamHost;
-    if (blockHost == null && streamHost == null) {
-      return;
+    if (streamHost == null) {
+      return super.size;
+    }
+
+    final streamSize = _streamSize;
+    if (streamSize != null) {
+      return streamSize;
+    }
+
+    throw UnsupportedError(
+      'Body.size is unavailable for stream-backed bodies with unknown length.',
+    );
+  }
+
+  @override
+  Stream<Uint8List> stream({int chunkSize = _defaultBlobChunkSize}) async* {
+    if (chunkSize <= 0) {
+      throw ArgumentError.value(chunkSize, 'chunkSize', 'Must be > 0');
     }
 
     _startConsumption();
 
-    if (blockHost != null) {
-      yield* blockHost.stream();
+    final streamHost = _streamHost;
+    if (streamHost != null) {
+      yield* streamHost;
       return;
     }
 
-    if (streamHost != null) {
-      yield* streamHost;
-    }
+    yield* super.stream(chunkSize: chunkSize);
   }
 
   bool get bodyUsed => _used;
 
-  Future<Uint8List> bytes() async {
+  @override
+  Future<Uint8List> bytes() => arrayBuffer();
+
+  @override
+  Future<Uint8List> arrayBuffer() async {
     final builder = BytesBuilder(copy: false);
-    await for (final chunk in stream) {
+    await for (final chunk in stream()) {
       builder.add(chunk);
     }
 
     return builder.takeBytes();
   }
 
+  @override
   Future<String> text([Encoding encoding = utf8]) async {
     return encoding.decode(await bytes());
   }
@@ -151,17 +125,12 @@ class Body extends Stream<Uint8List> {
   }
 
   Future<Blob> blob() async {
-    final blockHost = _blockHost;
-    if (blockHost != null) {
+    if (_streamHost == null) {
       _startConsumption();
-      if (blockHost case final Blob blob) {
-        return blob;
-      }
-
-      return Blob(<Object>[blockHost], blockHost.type);
+      return Blob(<BlobPart>[super.slice(0, null, type)], type);
     }
 
-    return Blob(<Object>[await bytes()]);
+    return Blob(<BlobPart>[await bytes()], type);
   }
 
   Body clone() {
@@ -169,23 +138,35 @@ class Body extends Stream<Uint8List> {
       throw StateError('Body has already been consumed.');
     }
 
-    final blockHost = _blockHost;
-    if (blockHost != null) {
-      return Body._(blockHost: blockHost, contentType: contentType);
-    }
-
     final streamHost = _streamHost;
-    if (streamHost != null) {
-      final (left, right) = streamTee(streamHost);
-      _streamHost = left;
+    if (streamHost == null) {
       return Body._(
-        streamHost: right,
-        byteLength: size,
+        blobParts: <BlobPart>[super.slice(0, null, type)],
+        type: type,
         contentType: contentType,
       );
     }
 
-    throw StateError('Body has no host.');
+    final (left, right) = streamTee(streamHost);
+    _streamHost = left;
+    return Body._(
+      streamHost: right,
+      streamSize: _streamSize,
+      type: type,
+      contentType: contentType,
+    );
+  }
+
+  @override
+  Blob slice(int start, [int? end, String? contentType]) {
+    if (_streamHost != null) {
+      throw UnsupportedError(
+        'Body.slice is unavailable for stream-backed bodies.',
+      );
+    }
+
+    final sliced = super.slice(start, end, contentType);
+    return Blob(<BlobPart>[sliced], sliced.type);
   }
 
   @override
@@ -195,7 +176,7 @@ class Body extends Stream<Uint8List> {
     void Function()? onDone,
     bool? cancelOnError,
   }) {
-    return stream.listen(
+    return stream().listen(
       onData,
       onError: onError,
       onDone: onDone,
@@ -209,6 +190,55 @@ class Body extends Stream<Uint8List> {
     }
 
     _used = true;
+  }
+
+  static Body _fromBlobInit(BodyInit init) {
+    final type = _blobInitType(init);
+    return Body._(
+      blobParts: _blobInitParts(init),
+      type: type,
+      contentType: _contentType(type),
+    );
+  }
+
+  static Body _fromFormData(FormData formData) {
+    final encoded = formData.encodeMultipart();
+    return Body._(
+      streamHost: encoded.stream,
+      streamSize: encoded.contentLength,
+      type: encoded.contentType,
+      contentType: encoded.contentType,
+    );
+  }
+
+  static Body _fromStream(Stream<List<int>> stream) {
+    return Body._(
+      streamHost: stream.map(
+        (chunk) => chunk is Uint8List ? chunk : Uint8List.fromList(chunk),
+      ),
+    );
+  }
+
+  static Iterable<BlobPart> _blobInitParts(BodyInit init) {
+    return switch (init) {
+      null => const <BlobPart>[],
+      final URLSearchParams params => <BlobPart>[params.toString()],
+      final ByteBuffer buffer => <BlobPart>[buffer.asUint8List()],
+      final List<int> bytes when bytes is! Uint8List => <BlobPart>[
+        Uint8List.fromList(bytes),
+      ],
+      _ => <BlobPart>[init],
+    };
+  }
+
+  static String _blobInitType(BodyInit init) {
+    return switch (init) {
+      final String _ => _textPlainUtf8,
+      final URLSearchParams _ => _urlEncodedUtf8,
+      final Blob blob => blob.type,
+      final block.Block blockHost => blockHost.type,
+      _ => '',
+    };
   }
 
   static String? _contentType(String type) => type.isEmpty ? null : type;

--- a/lib/src/fetch/body.dart
+++ b/lib/src/fetch/body.dart
@@ -15,6 +15,7 @@ import 'url_search_params.dart';
 /// - [String]
 /// - [Uint8List]
 /// - [ByteBuffer]
+/// - [ByteData]
 /// - [List<int>]
 /// - [Stream<List<int>>]
 /// - [Blob]
@@ -23,8 +24,8 @@ import 'url_search_params.dart';
 /// - [FormData]
 /// - [URLSearchParams]
 ///
-/// On IO, `dart:io File` values are supported as [Blob] parts. Wrap files in a
-/// [Blob] before passing them as [BodyInit], for example `Body(Blob([file]))`.
+/// On IO, `dart:io File` values are supported through the platform [Blob]
+/// implementation.
 ///
 /// Bodies normalize supported inputs into a detached [Blob] when
 /// possible. Platform implementations may accept additional host-backed inputs
@@ -35,7 +36,7 @@ const _textPlainUtf8 = 'text/plain;charset=UTF-8';
 const _urlEncodedUtf8 = 'application/x-www-form-urlencoded;charset=UTF-8';
 const _defaultBlobChunkSize = 16 * 1024;
 
-/// Native detached body implementation.
+/// Detached body implementation.
 ///
 /// This is the shared body baseline that web/io implementations align to.
 class Body extends Blob with Stream<Uint8List> implements Stream<Uint8List> {
@@ -55,7 +56,12 @@ class Body extends Blob with Stream<Uint8List> implements Stream<Uint8List> {
       final Body body => body.clone(),
       final FormData formData => Body._fromFormData(formData),
       final Stream<List<int>> stream => Body._fromStream(stream),
-      _ => Body._fromBlobInit(init),
+      final String text => Body._fromBlobInit(text, _textPlainUtf8),
+      final URLSearchParams params => Body._fromBlobInit(
+        params.toString(),
+        _urlEncodedUtf8,
+      ),
+      _ => Body._fromBlobInit(init, _blobInitType(init)),
     };
   }
 
@@ -84,11 +90,15 @@ class Body extends Blob with Stream<Uint8List> implements Stream<Uint8List> {
   }
 
   @override
-  Stream<Uint8List> stream({int chunkSize = _defaultBlobChunkSize}) async* {
+  Stream<Uint8List> stream({int chunkSize = _defaultBlobChunkSize}) {
     if (chunkSize <= 0) {
       throw ArgumentError.value(chunkSize, 'chunkSize', 'Must be > 0');
     }
 
+    return _stream(chunkSize);
+  }
+
+  Stream<Uint8List> _stream(int chunkSize) async* {
     _startConsumption();
 
     final streamHost = _streamHost;
@@ -107,12 +117,14 @@ class Body extends Blob with Stream<Uint8List> implements Stream<Uint8List> {
 
   @override
   Future<Uint8List> arrayBuffer() async {
-    final builder = BytesBuilder(copy: false);
-    await for (final chunk in stream()) {
-      builder.add(chunk);
+    _startConsumption();
+
+    final streamHost = _streamHost;
+    if (streamHost == null) {
+      return super.arrayBuffer();
     }
 
-    return builder.takeBytes();
+    return _readStream(streamHost);
   }
 
   @override
@@ -192,10 +204,9 @@ class Body extends Blob with Stream<Uint8List> implements Stream<Uint8List> {
     _used = true;
   }
 
-  static Body _fromBlobInit(BodyInit init) {
-    final type = _blobInitType(init);
+  static Body _fromBlobInit(BodyInit init, String type) {
     return Body._(
-      blobParts: _blobInitParts(init),
+      blobParts: init == null ? const <BlobPart>[] : <BlobPart>[init],
       type: type,
       contentType: _contentType(type),
     );
@@ -212,23 +223,16 @@ class Body extends Blob with Stream<Uint8List> implements Stream<Uint8List> {
   }
 
   static Body _fromStream(Stream<List<int>> stream) {
-    return Body._(
-      streamHost: stream.map(
-        (chunk) => chunk is Uint8List ? chunk : Uint8List.fromList(chunk),
-      ),
-    );
+    return Body._(streamHost: stream.map(Uint8List.fromList));
   }
 
-  static Iterable<BlobPart> _blobInitParts(BodyInit init) {
-    return switch (init) {
-      null => const <BlobPart>[],
-      final URLSearchParams params => <BlobPart>[params.toString()],
-      final ByteBuffer buffer => <BlobPart>[buffer.asUint8List()],
-      final List<int> bytes when bytes is! Uint8List => <BlobPart>[
-        Uint8List.fromList(bytes),
-      ],
-      _ => <BlobPart>[init],
-    };
+  static Future<Uint8List> _readStream(Stream<Uint8List> stream) async {
+    final builder = BytesBuilder(copy: false);
+    await for (final chunk in stream) {
+      builder.add(chunk);
+    }
+
+    return builder.takeBytes();
   }
 
   static String _blobInitType(BodyInit init) {

--- a/test/body_test.dart
+++ b/test/body_test.dart
@@ -11,6 +11,31 @@ import 'package:test/test.dart';
 
 Stream<Uint8List> expectNonNullableStream(Stream<Uint8List> stream) => stream;
 
+final class _ThrowingReadBlob extends platform_blob.Blob {
+  _ThrowingReadBlob(List<int> bytes, {String type = ''})
+    : super(<Object>[Uint8List.fromList(bytes)], type);
+
+  @override
+  Future<Uint8List> arrayBuffer() {
+    throw StateError('arrayBuffer should not be called');
+  }
+
+  @override
+  Future<Uint8List> bytes() {
+    throw StateError('bytes should not be called');
+  }
+
+  @override
+  Future<String> text() {
+    throw StateError('text should not be called');
+  }
+
+  @override
+  Stream<Uint8List> stream({int chunkSize = 16 * 1024}) {
+    throw StateError('stream should not be called');
+  }
+}
+
 void main() {
   group('Body', () {
     test('string bodies decode as text and bytes', () async {
@@ -73,6 +98,27 @@ void main() {
       expect(body.bodyUsed, isTrue);
     });
 
+    test('normalizes ordinary init values through Blob snapshots', () async {
+      final bytes = Uint8List.fromList([1, 2, 3]);
+      final body = Body(bytes);
+
+      bytes[0] = 9;
+
+      expect(await body.bytes(), [1, 2, 3]);
+    });
+
+    test('uses Blob backing without calling source read methods', () async {
+      final blob = _ThrowingReadBlob([
+        1,
+        2,
+        3,
+      ], type: 'application/octet-stream');
+      final body = Body(blob);
+
+      expect(body.contentType, 'application/octet-stream');
+      expect(await body.bytes(), [1, 2, 3]);
+    });
+
     test('exposes known byte size without consuming the body', () {
       final params = URLSearchParams({'a': '1', 'b': '2'});
       final formData = FormData()..append('a', Multipart.text('1'));
@@ -96,6 +142,26 @@ void main() {
       final body = Body(Stream<List<int>>.value(utf8.encode('stream')));
 
       expect(() => body.size, throwsUnsupportedError);
+      expect(body.bodyUsed, isFalse);
+    });
+
+    test('validates stream chunk size before consumption starts', () async {
+      final body = Body('hello');
+
+      expect(() => body.stream(chunkSize: 0), throwsArgumentError);
+      expect(body.bodyUsed, isFalse);
+
+      final stream = body.stream(chunkSize: 2);
+
+      expect(body.bodyUsed, isFalse);
+      expect(await stream.map(utf8.decode).join(), 'hello');
+      expect(body.bodyUsed, isTrue);
+    });
+
+    test('stream-backed bodies cannot be sliced', () {
+      final body = Body(Stream<List<int>>.value(utf8.encode('stream')));
+
+      expect(() => body.slice(0), throwsUnsupportedError);
       expect(body.bodyUsed, isFalse);
     });
 
@@ -126,6 +192,19 @@ void main() {
 
       expect(await body.text(), 'hello world');
       expect(await clone.text(), 'hello world');
+    });
+
+    test('stream chunks are copied when consumed', () async {
+      final controller = StreamController<List<int>>(sync: true);
+      final chunk = Uint8List.fromList([1, 2, 3]);
+      final body = Body(controller.stream);
+
+      final bytes = body.bytes();
+      controller.add(chunk);
+      chunk[0] = 9;
+      await controller.close();
+
+      expect(await bytes, [1, 2, 3]);
     });
 
     test('copying a stream-backed body preserves independent reads', () async {

--- a/test/body_test.dart
+++ b/test/body_test.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:block/block.dart' as block;
+import 'package:ht/src/fetch/blob.dart' as platform_blob;
 import 'package:ht/src/fetch/body.dart';
 import 'package:ht/src/fetch/form_data.native.dart';
 import 'package:ht/src/fetch/url_search_params.dart';
@@ -55,6 +56,23 @@ void main() {
       expect(Body([1, 2, 3]).contentType, isNull);
     });
 
+    test('extends platform Blob and implements Stream', () async {
+      final body = Body('hello');
+
+      expect(body, isA<platform_blob.Blob>());
+      expect(body, isA<Stream<Uint8List>>());
+      expect(body.type, 'text/plain;charset=utf-8');
+      expect(body.size, 5);
+
+      final slice = body.slice(1, 4);
+      expect(await slice.text(), 'ell');
+      expect(body.bodyUsed, isFalse);
+
+      final chunks = await expectNonNullableStream(body).toList();
+      expect(chunks.expand((chunk) => chunk).toList(), utf8.encode('hello'));
+      expect(body.bodyUsed, isTrue);
+    });
+
     test('exposes known byte size without consuming the body', () {
       final params = URLSearchParams({'a': '1', 'b': '2'});
       final formData = FormData()..append('a', Multipart.text('1'));
@@ -74,10 +92,10 @@ void main() {
       expect(formBody.bodyUsed, isFalse);
     });
 
-    test('reports null size for arbitrary stream bodies', () {
+    test('rejects size reads for arbitrary stream bodies', () {
       final body = Body(Stream<List<int>>.value(utf8.encode('stream')));
 
-      expect(body.size, isNull);
+      expect(() => body.size, throwsUnsupportedError);
       expect(body.bodyUsed, isFalse);
     });
 
@@ -145,7 +163,7 @@ void main() {
       'empty bodies return empty bytes and become used when consumed',
       () async {
         final body = Body();
-        final stream = expectNonNullableStream(body.stream);
+        final stream = expectNonNullableStream(body);
 
         expect(body.bodyUsed, isFalse);
         expect(await stream.toList(), isEmpty);

--- a/test/public_api_surface_test.dart
+++ b/test/public_api_surface_test.dart
@@ -1,3 +1,6 @@
+import 'dart:async';
+import 'dart:typed_data';
+
 import 'package:block/block.dart' as block;
 import 'package:ht/ht.dart';
 import 'package:test/test.dart';
@@ -42,6 +45,8 @@ void main() {
     expect(requestInit.method, 'POST');
     expect(requestInit.priority, RequestPriority.high);
     expect(responseInit.status, 200);
+    expect(body, isA<Blob>());
+    expect(body, isA<Stream<Uint8List>>());
     expect(body.size, 6);
     expect(request.headers.has('content-type'), isTrue);
     expect(await multipart.bytes(), isNotEmpty);


### PR DESCRIPTION
## Type
Refactor

## Summary
- Make `Body` extend the conditional platform `Blob` implementation and implement `Stream<Uint8List>` directly.
- Simplify `Body` construction by delegating Blob-compatible inputs to `Blob`, while keeping `Body`, `FormData`, and stream-specific handling in `Body`.
- Preserve Fetch body helpers and `bodyUsed` semantics, and update public surface coverage for the new inheritance shape.

## Notes
- This is a follow-up to #49.
- `Body` now depends on the conditional `blob.dart` surface rather than importing `blob.native.dart` directly.

## Validation
- `dart format --output=none --set-exit-if-changed .`
- `dart analyze`
- `dart test -p vm -p node -p chrome`

Closes #50

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * `Body.stream` is now a method with an optional `chunkSize` parameter; use `body.stream()` instead of `body.stream`.
  * `Body.size` may throw `UnsupportedError` for stream-backed bodies with unknown length.
  * `Body` now extends `Blob` and implements `Stream<Uint8List>`.

* **Documentation**
  * Updated changelog documenting breaking changes to the `Body` API and interface hierarchy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->